### PR TITLE
Scoped deployer permissions to cluster-admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ ZONE=us-west1-a
 # Create the cluster.
 gcloud beta container clusters create "$CLUSTER_NAME" \
     --zone "$ZONE" \
-    --cluster-version "1.8.7-gke.1" \
     --machine-type "n1-standard-1" \
     --num-nodes "3"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -77,13 +77,13 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: admin
+  name: cluster-admin
 subjects:
 - kind: ServiceAccount
   name: ${name}-deployer-sa
 EOF
 
-# Create Application instance (stitching in the expanded manifest).
+# Create Application instance.
 kubectl apply --namespace="$namespace" --filename=- <<EOF
 apiVersion: marketplace.cloud.google.com/v1
 kind: Application


### PR DESCRIPTION
Changed from clusterrole/admin, which does not allow for modification of Application resources.

Also removed `--cluster-version` from recommended gcloud command, as it can become stale over time.
Also removed a stale code comment.