### PR TITLE
Set default params for app without any app params

### DIFF
--- a/app.Makefile
+++ b/app.Makefile
@@ -19,7 +19,7 @@ ifdef APP_NAME
 endif
 
 ifndef APP_PARAMETERS
-  APP_PARAMETERS = '{}'
+  APP_PARAMETERS = {"APP_INSTANCE_NAME": "$(APP_INSTANCE_NAME)", "NAMESPACE": "$(NAMESPACE)"}
 endif
 
 APP_BUILD = .build/marketplace-app
@@ -99,7 +99,7 @@ endif
 	$(info ---- APP_REGISTRY       = $(APP_REGISTRY))
 	$(info ---- APP_TAG            = $(APP_TAG))
 	$(info ---- APP_PARAMETERS     = $(APP_PARAMETERS))
-	
+
 	@ [ -n "$$(which jq)" ] || echo 'Please install jq.' || exit 1
 
 endif

--- a/marketplace/deployer_util/setownership.py
+++ b/marketplace/deployer_util/setownership.py
@@ -51,7 +51,7 @@ if len(apps) > 1:
 
 kinds = map(lambda x: x['kind'], apps[0]['spec']['componentKinds'])
 
-excluded_kinds = [ "StatefulSet", "PersistentVolumeClaim", "Application" ]
+excluded_kinds = [ "PersistentVolumeClaim", "Application" ]
 included_kinds = [ kind for kind in kinds if kind not in excluded_kinds ]
 
 print("Owner references not set for " + ", ".join(excluded_kinds))
@@ -74,6 +74,6 @@ with open(args.dest, "w") as outfile:
       ownerReference['name'] = args.appname
       ownerReference['uid'] = args.appuid
       resource['metadata']['ownerReferences'].append(ownerReference)
-  
+
     outfile.write(docstart)
     yaml.dump(resource, outfile, default_flow_style=False)


### PR DESCRIPTION
For app without any app specific params, the deployer params end up
not being set (i.e. just an empty map), causing app/install to fail.

Also include StatefulSet in setownership.py.