### PR TITLE
Add always pull policy to deployer Job

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -147,6 +147,7 @@ spec:
       containers:
       - name: app
         image: "${deployer}"
+        imagePullPolicy: Always
         envFrom:
         - configMapRef:
             name: "${name}-deployer-config"


### PR DESCRIPTION
This is to avoid using a stale cached image when the deployer image
is specified using a tag instead of digest.