### PR TITLE
Use a different directory for expanded values

### DIFF
--- a/marketplace/deployer_util/expand_config.py
+++ b/marketplace/deployer_util/expand_config.py
@@ -45,9 +45,11 @@ class MissingRequiredProperty(Exception):
 def main():
   parser = ArgumentParser(description=_PROG_HELP)
   parser.add_argument('--values_dir',
-                      help='Where the value files should be read from '
-                      'and written back to',
+                      help='Where the value files should be read from',
                       default='/data/values')
+  parser.add_argument('--final_values_dir',
+                      help='Where the final value files should be written to',
+                      default='/data/final_values')
   parser.add_argument('--schema_file', help='Path to the schema file',
                       default='/data/schema.yaml')
   parser.add_argument('--encoding',
@@ -58,7 +60,7 @@ def main():
   schema = read_schema(args.schema_file)
   values = read_values_to_dict(args.values_dir, args.encoding)
   values = expand(values, schema)
-  write_values(values, args.values_dir, args.encoding)
+  write_values(values, args.final_values_dir, args.encoding)
 
 
 def read_schema(schema_file):
@@ -114,6 +116,8 @@ def generate_password(config):
 
 
 def write_values(values, values_dir, encoding):
+  if not os.path.exists(values_dir):
+    os.makedirs(values_dir)
   for k, v in values.iteritems():
     file_path = os.path.join(values_dir, k)
     with open(file_path, 'w') as f:

--- a/marketplace/deployer_util/print_config.py
+++ b/marketplace/deployer_util/print_config.py
@@ -45,7 +45,7 @@ def main():
                       choices=[OUTPUT_SHELL, OUTPUT_YAML],
                       default=OUTPUT_SHELL)
   parser.add_argument('--values_dir', help='Where to read value files',
-                      default='/data/values')
+                      default='/data/final_values')
   parser.add_argument('--param',
                       help='If specified, outputs the value of a single '
                       'parameter, unescaped.')


### PR DESCRIPTION
Starting from 1.9, mounting a config map onto a directory
puts that directory on a read-only file system. It also
overrides any existing content on that directory.