### PR TITLE
Fix for yaml2json to handle serializing datetime objects.

### DIFF
--- a/marketplace/deployer_util/yaml2json
+++ b/marketplace/deployer_util/yaml2json
@@ -14,12 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import json
 import sys
 import yaml
-import json
 
 from subprocess import Popen, PIPE, STDOUT
 
+def _fallback_serializer(obj):
+  """JSON serializer for objects not serializable by default json code"""
+  if isinstance(obj, (datetime.datetime, datetime.date)):
+    return obj.isoformat()
+  raise TypeError ("Type %s not serializable" % type(obj))
+
 content = sys.stdin.read()
 for loaded in yaml.load_all(content):
-  print(json.dumps(loaded))
+  print(json.dumps(loaded, default=_fallback_serializer))


### PR DESCRIPTION
Same change as https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/pull/113, but `master` instead of `trironkk/dev/c`.