### PR TITLE
crd.Makefile: remove non-existing common/setup dependency from crd/install

### DIFF
--- a/crd.Makefile
+++ b/crd.Makefile
@@ -8,12 +8,12 @@ include $(makefile_dir)/common.Makefile
 
 # Installs the application CRD on the cluster.
 .PHONY: crd/install
-crd/install: | common/setup
+crd/install:
 	kubectl apply -f "$(MARKETPLACE_TOOLS_PATH)/crd/app-crd.yaml"
 
 # Uninstalls the application CRD from the cluster.
 .PHONY: crd/uninstall
-crd/uninstall: | common/setup
+crd/uninstall:
 	kubectl delete -f "$(MARKETPLACE_TOOLS_PATH)/crd/app-crd.yaml"
 
 


### PR DESCRIPTION
make crd/install was failing due to a dependency on non-existing target - "common/setup";
common/setup was removed in a6293c9266fcec115d714ebccbcf3a10f630b31a