### PR TITLE
Increase the wait timeout for driver.sh from 300 to 600 seconds

### DIFF
--- a/marketplace/driver/driver.sh
+++ b/marketplace/driver/driver.sh
@@ -45,7 +45,7 @@ done
 [[ -z "$deployer" ]] && deployer="$APP_DEPLOYER_IMAGE"
 [[ -z "$parameters" ]] && parameters="{}"
 [[ -z "$marketplace_tools" ]] && echo "--marketplace_tools required" && exit 1
-[[ -z "$wait_timeout" ]] && wait_timeout=300
+[[ -z "$wait_timeout" ]] && wait_timeout=600
 
 # Getting the directory of the running script
 DIR="$(realpath $(dirname $0))"


### PR DESCRIPTION
My verification builds are failing because one of the pods needs more time to get removed.