### PR TITLE
Convert usage of xxd to tr for compatibility.

### DIFF
--- a/scripts/driver/driver.sh
+++ b/scripts/driver/driver.sh
@@ -52,7 +52,7 @@ NAME="$(echo "$parameters" \
     --values_file=- --param '{"x-google-marketplace": {"type": "NAME"}}')"
 
 export NAMESPACE="apptest-$(cat /dev/urandom \
-    | tr -dc 'a-zA-Z0-9' \
+    | tr -dc 'a-z0-9' \
     | fold -w 8 \
     | head -n 1)"
 export NAME


### PR DESCRIPTION
I feel bad for suggesting `xxd` - it's installed as a component of `vim-common`, which makes sense why I'd be familiar with it, but `tr` is in `coreutils`, which is more ubiquitous. This approach also squeezes more entropy into the 8 characters.