### PR TITLE
use base64 for BSD systems where tr won't handle illegal characters

### DIFF
--- a/scripts/driver/driver.sh
+++ b/scripts/driver/driver.sh
@@ -51,7 +51,9 @@ NAME="$(echo "$parameters" \
     | docker run -i --entrypoint=/bin/print_config.py --rm "$deployer" \
     --values_file=- --param '{"x-google-marketplace": {"type": "NAME"}}')"
 
+# use base64 for BSD systems where tr won't handle illegal characters
 export NAMESPACE="apptest-$(cat /dev/urandom \
+    | base64 \
     | tr -dc 'a-z0-9' \
     | fold -w 8 \
     | head -n 1)"


### PR DESCRIPTION
The GNU version of 'tr' will ignore illegal characters, the BSD
version does not and will fail with 'illegal byte sequence'.