### PR TITLE
Reparenting marketplace/dev image to be based on official gcloud image.

### DIFF
--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM gcr.io/cloud-builders/gcloud
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -19,15 +19,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN pip install wheel \
     && pip install google-cloud-storage
-
-RUN wget -q -O /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl \
-    && chmod 755 /bin/kubectl
-
-RUN wget -q -O /usr/bin/google-cloud-sdk-199.0.0-linux-x86_64.tar.gz \
-        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-199.0.0-linux-x86_64.tar.gz \
-    && tar xfC /usr/bin/google-cloud-sdk-199.0.0-linux-x86_64.tar.gz /usr/bin \
-    && ln -s /usr/bin/google-cloud-sdk/bin/gcloud /usr/bin/gcloud \
-    && chmod 755 /usr/bin/google-cloud-sdk/bin/gcloud
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     apt-key fingerprint 0EBFCD88 && \


### PR DESCRIPTION
This pull simplifies the handling of kubectl credentials files (removing need to mount volumes) and improves Cloudbuild performance (`gcr.io/cloud-builders/gcloud` image is already cached).