### PR TITLE
Use applicationApiVersion, still supporting old name

### DIFF
--- a/app.Makefile
+++ b/app.Makefile
@@ -28,6 +28,9 @@ $(shell echo '$(APP_PARAMETERS)' '$(APP_TEST_PARAMETERS)' \
     | docker run -i --entrypoint=/usr/bin/jq --rm $(APP_DEPLOYER_IMAGE) -s '.[0] * .[1]')
 endef
 
+KUBE_CONFIG ?= $(HOME)/.kube
+GCLOUD_CONFIG ?= $(HOME)/.config/gcloud
+
 
 .build/app: | .build
 	mkdir -p "$@"
@@ -54,8 +57,8 @@ app/install:: app/build \
 	$(call print_target)
 	docker run \
 	    --volume "/var/run/docker.sock:/var/run/docker.sock:ro" \
-	    --volume "$(HOME)/.kube:/root/mount/.kube:ro" \
-	    --volume "$(HOME)/.config/gcloud:/root/mount/.config/gcloud:ro" \
+	    --volume "$(KUBE_CONFIG):/root/mount/.kube:ro" \
+	    --volume "$(GCLOUD_CONFIG):/root/mount/.config/gcloud:ro" \
 	    --rm \
 	    "gcr.io/cloud-marketplace-tools/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
 	    -- \
@@ -76,8 +79,8 @@ app/install-test:: app/build \
 	$(call print_target)
 	docker run \
 	    --volume "/var/run/docker.sock:/var/run/docker.sock:ro" \
-	    --volume "$(HOME)/.kube:/root/mount/.kube:ro" \
-	    --volume "$(HOME)/.config/gcloud:/root/mount/.config/gcloud:ro" \
+	    --volume "$(KUBE_CONFIG):/root/mount/.kube:ro" \
+	    --volume "$(GCLOUD_CONFIG):/root/mount/.config/gcloud:ro" \
 	    --rm \
 	    "gcr.io/cloud-marketplace-tools/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
 	    -- \
@@ -108,8 +111,8 @@ app/verify: app/build \
 	$(call print_target)
 	docker run \
 	    --volume "/var/run/docker.sock:/var/run/docker.sock:ro" \
-	    --volume "$(HOME)/.kube:/root/mount/.kube:ro" \
-	    --volume "$(HOME)/.config/gcloud:/root/mount/.config/gcloud:ro" \
+	    --volume "$(KUBE_CONFIG):/root/mount/.kube:ro" \
+	    --volume "$(GCLOUD_CONFIG):/root/mount/.config/gcloud:ro" \
 	    --rm \
 	    "gcr.io/cloud-marketplace-tools/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
 	    -- \

--- a/app.Makefile
+++ b/app.Makefile
@@ -63,8 +63,8 @@ app/install:: app/build \
 	    "gcr.io/cloud-marketplace-tools/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
 	    -- \
 	    /scripts/install \
-	          --deployer="$(APP_DEPLOYER_IMAGE)" \
-	          --parameters="$(APP_PARAMETERS)" \
+	          --deployer='$(APP_DEPLOYER_IMAGE)' \
+	          --parameters='$(APP_PARAMETERS)' \
 	          --entrypoint="/bin/deploy.sh"
 
 
@@ -85,8 +85,8 @@ app/install-test:: app/build \
 	    "gcr.io/cloud-marketplace-tools/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
 	    -- \
 	    /scripts/install \
-	          --deployer="$(APP_DEPLOYER_IMAGE)" \
-	          --parameters="$(call combined_parameters)" \
+	          --deployer='$(APP_DEPLOYER_IMAGE)' \
+	          --parameters='$(call combined_parameters)' \
 	          --entrypoint="/bin/deploy_with_tests.sh"
 
 

--- a/marketplace.Makefile
+++ b/marketplace.Makefile
@@ -6,6 +6,7 @@ COMMIT ?= $(shell git rev-parse HEAD | fold -w 12 | head -n 1)
 
 makefile_dir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include $(makefile_dir)/common.Makefile
+include $(makefile_dir)/var.Makefile
 
 
 .build/marketplace: | .build
@@ -16,6 +17,7 @@ include $(makefile_dir)/common.Makefile
                         $(MARKETPLACE_TOOLS_PATH)/marketplace/dev/* \
                         $(MARKETPLACE_TOOLS_PATH)/scripts/* \
                         $(MARKETPLACE_TOOLS_PATH)/marketplace.Makefile \
+                        .build/var/MARKETPLACE_TOOLS_TAG \
                         | .build/marketplace
 	$(call print_target)
 	cd "$(MARKETPLACE_TOOLS_PATH)" ; \
@@ -33,6 +35,7 @@ include $(makefile_dir)/common.Makefile
 .build/marketplace/deployer/envsubst: $(MARKETPLACE_TOOLS_PATH)/marketplace/deployer_util/* \
                                       $(MARKETPLACE_TOOLS_PATH)/marketplace/deployer_envsubst_base/* \
                                       .build/marketplace/delete_deprecated \
+                                      .build/var/MARKETPLACE_TOOLS_TAG \
                                       | .build/marketplace/deployer
 	$(call print_target)
 	cd "$(MARKETPLACE_TOOLS_PATH)"; \
@@ -46,6 +49,8 @@ include $(makefile_dir)/common.Makefile
 .build/marketplace/deployer/helm: $(MARKETPLACE_TOOLS_PATH)/marketplace/deployer_util/* \
                                   $(MARKETPLACE_TOOLS_PATH)/marketplace/deployer_helm_base/* \
                                   .build/marketplace/delete_deprecated \
+                                  .build/var/COMMIT \
+                                  .build/var/MARKETPLACE_TOOLS_TAG \
                                   | .build/marketplace/deployer
 	$(call print_target)
 	cd $(MARKETPLACE_TOOLS_PATH) \

--- a/marketplace.Makefile
+++ b/marketplace.Makefile
@@ -15,7 +15,6 @@ include $(makefile_dir)/common.Makefile
 .build/marketplace/dev: $(MARKETPLACE_TOOLS_PATH)/marketplace/deployer_util/* \
                         $(MARKETPLACE_TOOLS_PATH)/marketplace/dev/* \
                         $(MARKETPLACE_TOOLS_PATH)/scripts/* \
-                        $(MARKETPLACE_TOOLS_PATH)/scripts/driver/* \
                         $(MARKETPLACE_TOOLS_PATH)/marketplace.Makefile \
                         | .build/marketplace
 	$(call print_target)

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -106,12 +106,14 @@ class Schema:
       raise InvalidSchema('Undefined property names found in required: {}'
                           .format(', '.join(bad_required_names)))
 
-    self._app_api_version = dictionary.get('application_api_version', None)
+    self._app_api_version = dictionary.get(
+        'applicationApiVersion', dictionary.get('application_api_version',
+                                                None))
 
   def validate(self):
     """Fully validates the schema, raising InvalidSchema if fails."""
     if self.app_api_version is None:
-      raise InvalidSchema('application_api_version is required')
+      raise InvalidSchema('applicationApiVersion is required')
 
   @property
   def app_api_version(self):

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -443,16 +443,35 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_good(self):
     schema = config_helper.Schema.load_yaml("""
-        application_api_version: v1beta1
+        applicationApiVersion: v1beta1
         properties:
           simple:
             type: string
         """)
     schema.validate()
 
+  def test_app_api_version_alternative_names(self):
+    schema = config_helper.Schema.load_yaml("""
+        applicationApiVersion: v1beta1
+        properties:
+          simple:
+            type: string
+        """)
+    schema.validate()
+    self.assertEqual(schema.app_api_version, 'v1beta1')
+
+    schema = config_helper.Schema.load_yaml("""
+        application_api_version: v1beta1
+        properties:
+          simple:
+            type: string
+        """)
+    schema.validate()
+    self.assertEqual(schema.app_api_version, 'v1beta1')
+
   def test_validate_missing_app_api_version(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, 'application_api_version',
+        config_helper.InvalidSchema, 'applicationApiVersion',
         lambda: config_helper.Schema.load_yaml("""
             properties:
               simple:

--- a/marketplace/deployer_util/expand_config_test.py
+++ b/marketplace/deployer_util/expand_config_test.py
@@ -24,7 +24,7 @@ class ExpandConfigTest(unittest.TestCase):
 
   def test_defaults(self):
     schema = config_helper.Schema.load_yaml("""
-        application_api_version: v1beta1
+        applicationApiVersion: v1beta1
         properties:
           p1:
             type: string
@@ -39,7 +39,7 @@ class ExpandConfigTest(unittest.TestCase):
 
   def test_invalid_value_type(self):
     schema = config_helper.Schema.load_yaml("""
-        application_api_version: v1beta1
+        applicationApiVersion: v1beta1
         properties:
           p1:
             type: string
@@ -50,7 +50,7 @@ class ExpandConfigTest(unittest.TestCase):
 
   def test_generate_properties_for_image_split_by_colon(self):
     schema = config_helper.Schema.load_yaml("""
-        application_api_version: v1beta1
+        applicationApiVersion: v1beta1
         properties:
           i1:
             type: string
@@ -71,7 +71,7 @@ class ExpandConfigTest(unittest.TestCase):
 
   def test_generate_properties_for_string_base64_encoded(self):
     schema = config_helper.Schema.load_yaml("""
-        application_api_version: v1beta1
+        applicationApiVersion: v1beta1
         properties:
           s1:
             type: string
@@ -89,7 +89,7 @@ class ExpandConfigTest(unittest.TestCase):
 
   def test_generate_password(self):
     schema = config_helper.Schema.load_yaml("""
-        application_api_version: v1beta1
+        applicationApiVersion: v1beta1
         properties:
           p1:
             type: string
@@ -106,7 +106,7 @@ class ExpandConfigTest(unittest.TestCase):
 
   def test_write_values(self):
     schema = config_helper.Schema.load_yaml("""
-        application_api_version: v1beta1
+        applicationApiVersion: v1beta1
         properties:
           propertyInt:
             type: int

--- a/marketplace/deployer_util/print_app_api_version.py
+++ b/marketplace/deployer_util/print_app_api_version.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python2
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from argparse import ArgumentParser
+
+import config_helper
+
+_PROG_HELP = """
+Prints the applicationApiVersion defined in the schema file.
+"""
+
+
+def main():
+  parser = ArgumentParser(description=_PROG_HELP)
+  parser.add_argument(
+      '--schema_file',
+      help='Path to the schema file',
+      default='/data/schema.yaml')
+  args = parser.parse_args()
+
+  schema = config_helper.Schema.load_yaml_file(args.schema_file)
+  sys.stdout.write(schema.app_api_version)
+  sys.stdout.flush()
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/install
+++ b/scripts/install
@@ -65,12 +65,8 @@ namespace="$(print_config.py \
     --schema_file=/data/schema.yaml \
     --values_file=/data/values.yaml \
     --param='{"x-google-marketplace": {"type": "NAMESPACE"}}')"
-app_version="$(cat /data/schema.yaml \
-  | yaml2json \
-  | jq -r 'if .application_api_version
-           then .application_api_version
-           else "v1alpha1"
-           end')"
+app_version="$(print_app_api_version.py \
+    --schema_file=/data/schema.yaml)"
 
 # Create Application instance.
 kubectl apply --namespace="$namespace" --filename=- <<EOF


### PR DESCRIPTION
Also include a few fixes to broken Makefiles, and a short-term fix for gcloud config overriding, as indicated in #207.