### PR TITLE
Limit the length of names of RBAC resources.

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -273,7 +273,7 @@ def provision_service_account(schema, prop, app_name, namespace):
         'kind': 'RoleBinding',
         'metadata': {
             'name':
-                limit_name('{}:{}:{}-rb'.format(app_name, prop.name, role)),
+                limit_name('{}:{}:{}-rb'.format(app_name, prop.name, role), 64),
             'namespace':
                 namespace,
         },
@@ -291,8 +291,9 @@ def provision_service_account(schema, prop, app_name, namespace):
         'kind': 'ClusterRoleBinding',
         'metadata': {
             'name':
-                limit_name('{}:{}:{}:{}-crb'.format(namespace, app_name,
-                                                    prop.name, role)),
+                limit_name(
+                    '{}:{}:{}:{}-crb'.format(namespace, app_name, prop.name,
+                                             role), 64),
             'namespace':
                 namespace,
         },
@@ -359,10 +360,11 @@ def dns1123_name(name):
   fixed = re.sub(r'[.]', '-', fixed)
   fixed = re.sub(r'[^a-z0-9-]', '', fixed)
   fixed = fixed.strip('-')
-  fixed = limit_name(fixed)
+  fixed = limit_name(fixed, 64)
   return fixed
 
-def limit_name(name, length=64):
+
+def limit_name(name, length=127):
   result = name
   if len(result) > length:
     result = result[:length - 5]

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -272,8 +272,10 @@ def provision_service_account(schema, prop, app_name, namespace):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'RoleBinding',
         'metadata': {
-            'name': '{}:{}:{}-rb'.format(app_name, prop.name, role),
-            'namespace': namespace,
+            'name':
+                dns1123_name('{}:{}:{}-crb'.format(app_name, prop.name, role)),
+            'namespace':
+                namespace,
         },
         'roleRef': {
             'apiGroup': 'rbac.authorization.k8s.io',
@@ -289,7 +291,8 @@ def provision_service_account(schema, prop, app_name, namespace):
         'kind': 'ClusterRoleBinding',
         'metadata': {
             'name':
-                '{}:{}:{}:{}-rb'.format(namespace, app_name, prop.name, role),
+                dns1123_name('{}:{}:{}:{}-crb'.format(namespace, app_name,
+                                                      prop.name, role)),
             'namespace':
                 namespace,
         },
@@ -300,7 +303,7 @@ def provision_service_account(schema, prop, app_name, namespace):
         },
         'subjects': subjects,
     })
-  return sa_name, add_preprovisioned_labels(manifests, sa_name)
+  return sa_name, add_preprovisioned_labels(manifests, prop.name)
 
 
 def provision_storage_class(schema, prop, app_name, namespace):
@@ -319,7 +322,7 @@ def provision_storage_class(schema, prop, app_name, namespace):
             'type': 'pd-ssd',
         }
     }]
-    return sc_name, add_preprovisioned_labels(manifests, sc_name)
+    return sc_name, add_preprovisioned_labels(manifests, prop.name)
   else:
     raise Exception('Do not know how to provision for property {}'.format(
         prop.name))

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -273,7 +273,7 @@ def provision_service_account(schema, prop, app_name, namespace):
         'kind': 'RoleBinding',
         'metadata': {
             'name':
-                dns1123_name('{}:{}:{}-crb'.format(app_name, prop.name, role)),
+                limit_name('{}:{}:{}-rb'.format(app_name, prop.name, role)),
             'namespace':
                 namespace,
         },
@@ -291,8 +291,8 @@ def provision_service_account(schema, prop, app_name, namespace):
         'kind': 'ClusterRoleBinding',
         'metadata': {
             'name':
-                dns1123_name('{}:{}:{}:{}-crb'.format(namespace, app_name,
-                                                      prop.name, role)),
+                limit_name('{}:{}:{}:{}-crb'.format(namespace, app_name,
+                                                    prop.name, role)),
             'namespace':
                 namespace,
         },
@@ -359,17 +359,19 @@ def dns1123_name(name):
   fixed = re.sub(r'[.]', '-', fixed)
   fixed = re.sub(r'[^a-z0-9-]', '', fixed)
   fixed = fixed.strip('-')
-  if len(fixed) > 64:
-    fixed = fixed[:59]
+  fixed = limit_name(fixed)
+  return fixed
 
-  # Add a hash at the end if the name has been modified.
-  if fixed != name:
+def limit_name(name, length=64):
+  result = name
+  if len(result) > length:
+    result = result[:length - 5]
     # Hash and get the first 4 characters of the hash.
     m = hashlib.sha256()
     m.update(name)
     h4sh = m.hexdigest()[:4]
-    fixed = '{}-{}'.format(fixed, h4sh)
-  return fixed
+    result = '{}-{}'.format(result, h4sh)
+  return result
 
 
 def add_preprovisioned_labels(manifests, prop_name):

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -15,25 +15,30 @@
 import unittest
 
 from provision import dns1123_name
+from provision import limit_name
 
 
 class ProvisionTest(unittest.TestCase):
 
   def test_dns1123_name(self):
     self.assertEqual(dns1123_name('valid-name'), 'valid-name')
-    self.assertModifiedName(dns1123_name('aA'), 'aa')
-    self.assertModifiedName(
+    self.assertEqual(dns1123_name('aA'), 'aa')
+    self.assertEqual(
         dns1123_name('*sp3cial-@chars.(rem0ved^'), 'sp3cial-chars-rem0ved')
-    self.assertModifiedName(dns1123_name('-abc.def.'), 'abc-def')
-    self.assertModifiedName(dns1123_name('-123.456.'), '123-456')
+    self.assertEqual(dns1123_name('-abc.def.'), 'abc-def')
+    self.assertEqual(dns1123_name('-123.456.'), '123-456')
     self.assertModifiedName(
-        dns1123_name('very-long-Name-that-gets-chopped-at-a-dash-'
-                     '-------------------------------------------'),
-        'very-long-name-that-gets-chopped-at-a-dash')
+        dns1123_name('Lorem-Ipsum-is-simply-dummy-text-of-the-printing-and-'
+                     'typesettings-----------------------------------------'),
+        'lorem-ipsum-is-simply-dummy-text-of-the-printing-and-typese')
     self.assertModifiedName(
-        dns1123_name('very-long-Name-that-gets-chopped-at-a-dot-'
-                     '...........................................'),
-        'very-long-name-that-gets-chopped-at-a-dot')
+        dns1123_name('Lorem-Ipsum-is-simply-dummy-text-of-the-printing-and-'
+                     'typesettings.........................................'),
+        'lorem-ipsum-is-simply-dummy-text-of-the-printing-and-typese')
+
+  def test_limit_name(self):
+    self.assertEqual(limit_name('valid-name'), 'valid-name')
+    self.assertEqual(limit_name('valid-name', 8), 'val-030a')
 
   def assertModifiedName(self, text, expected):
     self.assertEqual(text[:-5], expected)


### PR DESCRIPTION
Also corrects the value passed to the labels.