### PR TITLE
Do not use arrays in expect

### DIFF
--- a/testrunner/specs/specs.go
+++ b/testrunner/specs/specs.go
@@ -51,7 +51,7 @@ type GcpAction struct {
 }
 
 type BashTest struct {
-	Script string      `json:"script"`
+	Script string     `json:"script"`
 	Expect *CliExpect `json:"expect"`
 }
 
@@ -62,9 +62,9 @@ type HttpExpect struct {
 }
 
 type CliExpect struct {
-	ExitCode *[]IntAssert    `json:"exitCode,omitempty"`
-	Stdout   *[]StringAssert `json:"stdout,omitempty"`
-	Stderr   *[]StringAssert `json:"stderr,omitempty"`
+	ExitCode *IntAssert    `json:"exitCode,omitempty"`
+	Stdout   *StringAssert `json:"stdout,omitempty"`
+	Stderr   *StringAssert `json:"stderr,omitempty"`
 }
 
 type SetRuntimeConfigVarGcpAction struct {

--- a/testrunner/specs/specs_test.go
+++ b/testrunner/specs/specs_test.go
@@ -82,21 +82,19 @@ func expectedSuite() *Suite {
 				BashTest: &BashTest{
 					Script: "echo \"Text1\"\n>2& echo \"Text2\"",
 					Expect: &CliExpect{
-						ExitCode: &[]IntAssert{
-							{Equals: newInt(0)},
-							{NotEquals: newInt(1)},
+						ExitCode: &IntAssert{
+							Equals:    newInt(0),
+							NotEquals: newInt(1),
 						},
-						Stdout: &[]StringAssert{
-							{Contains: newString("Text1")},
-							{NotContains: newString("Foo")},
-							{NotContains: newString("Bar")},
-							{Matches: newString("T.xt1")},
+						Stdout: &StringAssert{
+							Contains:    newString("Text1"),
+							NotContains: newString("Foo"),
+							Matches:     newString("T.xt1"),
 						},
-						Stderr: &[]StringAssert{
-							{Contains: newString("Text2")},
-							{NotContains: newString("Foo")},
-							{NotContains: newString("Bar")},
-							{Matches: newString("T.xt2")},
+						Stderr: &StringAssert{
+							Contains:    newString("Text2"),
+							NotContains: newString("Foo"),
+							Matches:     newString("T.xt2"),
 						},
 					},
 				},

--- a/testrunner/specs/testdata/suite.json
+++ b/testrunner/specs/testdata/suite.json
@@ -36,29 +36,20 @@
       "bashTest": {
         "script": "echo \"Text1\"\n>2& echo \"Text2\"",
         "expect": {
-           "exitCode": [{
-             "equals": 0
-           },{
-             "notEquals": 1
-           }],
-          "stdout": [{
-            "contains": "Text1"
-          },{
-            "notContains": "Foo"
-          },{
-            "notContains": "Bar"
-          },{
+          "exitCode": {
+            "equals": 0,
+            "notEquals": 1
+          },
+          "stdout": {
+            "contains": "Text1",
+            "notContains": "Foo",
             "matches": "T.xt1"
-          }],
-          "stderr": [{
-            "contains": "Text2"
-          },{
-            "notContains": "Foo"
-          },{
-            "notContains": "Bar"
-          },{
+          },
+          "stderr": {
+            "contains": "Text2",
+            "notContains": "Foo",
             "matches": "T.xt2"
-          }]
+          }
         }
       }
     }

--- a/testrunner/specs/testdata/suite.yaml
+++ b/testrunner/specs/testdata/suite.yaml
@@ -24,15 +24,13 @@ actions:
       >2& echo "Text2"
     expect:
       exitCode:
-        - equals: 0
-        - notEquals: 1
+        equals: 0
+        notEquals: 1
       stdout:
-        - contains: "Text1"
-        - notContains: "Foo"
-        - notContains: "Bar"
-        - matches: "T.xt1"
+        contains: "Text1"
+        notContains: "Foo"
+        matches: "T.xt1"
       stderr:
-        - contains: "Text2"
-        - notContains: "Foo"
-        - notContains: "Bar"
-        - matches: "T.xt2"
+        contains: "Text2"
+        notContains: "Foo"
+        matches: "T.xt2"

--- a/testrunner/tests/bash.go
+++ b/testrunner/tests/bash.go
@@ -97,25 +97,21 @@ func validateResult(status int, stdout, stderr string, test *specs.BashTest) str
 	return ""
 }
 
-func validateErrorCode(status int, expect *[]specs.IntAssert) string {
+func validateErrorCode(status int, expect *specs.IntAssert) string {
 	if expect != nil {
-		for _, assert := range *expect {
-			result := asserts.DoAssert(status, assert)
-			if result != "" {
-				return result
-			}
+		result := asserts.DoAssert(status, expect)
+		if result != "" {
+			return result
 		}
 	}
 	return ""
 }
 
-func validateBufferedOutput(out string, expect *[]specs.StringAssert) string {
+func validateBufferedOutput(out string, expect *specs.StringAssert) string {
 	if expect != nil {
-		for _, assert := range *expect {
-			result := asserts.DoAssert(out, assert)
-			if result != "" {
-				return result
-			}
+		result := asserts.DoAssert(out, expect)
+		if result != "" {
+			return result
 		}
 	}
 	return ""

--- a/testrunner/tests/bash_test.go
+++ b/testrunner/tests/bash_test.go
@@ -32,14 +32,14 @@ func (e *SimpleSetupExecutor) RunTest(test *specs.BashTest) (int, string, string
 func TestSimpleSetup(t *testing.T) {
 	shouldPass(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			ExitCode: &[]specs.IntAssert{
-				{Equals: newInt(0)},
+			ExitCode: &specs.IntAssert{
+				Equals: newInt(0),
 			},
-			Stdout: &[]specs.StringAssert{
-				{Exactly: newString("FOO")},
+			Stdout: &specs.StringAssert{
+				Exactly: newString("FOO"),
 			},
-			Stderr: &[]specs.StringAssert{
-				{Exactly: newString("BAR")},
+			Stderr: &specs.StringAssert{
+				Exactly: newString("BAR"),
 			},
 		},
 	}, &SimpleSetupExecutor{})
@@ -54,14 +54,14 @@ func (e *FailingExecutor) RunTest(test *specs.BashTest) (int, string, string, er
 func TestFailingExecutor(t *testing.T) {
 	shouldFail(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			ExitCode: &[]specs.IntAssert{
-				{Equals: newInt(0)},
+			ExitCode: &specs.IntAssert{
+				Equals: newInt(0),
 			},
-			Stdout: &[]specs.StringAssert{
-				{Exactly: newString("FOO")},
+			Stdout: &specs.StringAssert{
+				Exactly: newString("FOO"),
 			},
-			Stderr: &[]specs.StringAssert{
-				{Exactly: newString("BAR")},
+			Stderr: &specs.StringAssert{
+				Exactly: newString("BAR"),
 			},
 		},
 	}, &FailingExecutor{})
@@ -76,41 +76,40 @@ func (e *ExitCodeExecutor) RunTest(test *specs.BashTest) (int, string, string, e
 func TestExitCodeParsing(t *testing.T) {
 	shouldPass(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			ExitCode: &[]specs.IntAssert{
-				{Equals: newInt(42)},
+			ExitCode: &specs.IntAssert{
+				Equals: newInt(42),
 			},
 		},
 	}, &ExitCodeExecutor{})
 
 	shouldPass(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			ExitCode: &[]specs.IntAssert{
-				{Equals: newInt(42)},
-				{Equals: newInt(42)},
-				{NotEquals: newInt(41)},
-				{GreaterThan: newInt(41)},
+			ExitCode: &specs.IntAssert{
+				Equals:      newInt(42),
+				NotEquals:   newInt(41),
+				GreaterThan: newInt(41),
 			},
-			Stdout: &[]specs.StringAssert{
-				{Exactly: newString("")},
+			Stdout: &specs.StringAssert{
+				Exactly: newString(""),
 			},
-			Stderr: &[]specs.StringAssert{
-				{Exactly: newString("")},
-			},
-		},
-	}, &ExitCodeExecutor{})
-
-	shouldFail(t, &specs.BashTest{
-		Expect: &specs.CliExpect{
-			ExitCode: &[]specs.IntAssert{
-				{Equals: newInt(0)},
+			Stderr: &specs.StringAssert{
+				Exactly: newString(""),
 			},
 		},
 	}, &ExitCodeExecutor{})
 
 	shouldFail(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			ExitCode: &[]specs.IntAssert{
-				{LessThan: newInt(40)},
+			ExitCode: &specs.IntAssert{
+				Equals: newInt(0),
+			},
+		},
+	}, &ExitCodeExecutor{})
+
+	shouldFail(t, &specs.BashTest{
+		Expect: &specs.CliExpect{
+			ExitCode: &specs.IntAssert{
+				LessThan: newInt(40),
 			},
 		},
 	}, &ExitCodeExecutor{})
@@ -125,40 +124,40 @@ func (e *StdoutExecutor) RunTest(test *specs.BashTest) (int, string, string, err
 func TestStdoutParsing(t *testing.T) {
 	shouldPass(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			Stdout: &[]specs.StringAssert{
-				{Exactly: newString("Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nProin nibh augue, suscipit a, scelerisque sed, lacinia in, mi.")},
+			Stdout: &specs.StringAssert{
+				Exactly: newString("Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nProin nibh augue, suscipit a, scelerisque sed, lacinia in, mi."),
 			},
 		},
 	}, &StdoutExecutor{})
 
 	shouldPass(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			ExitCode: &[]specs.IntAssert{
-				{Equals: newInt(0)},
+			ExitCode: &specs.IntAssert{
+				Equals: newInt(0),
 			},
-			Stdout: &[]specs.StringAssert{
-				{Exactly: newString("Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nProin nibh augue, suscipit a, scelerisque sed, lacinia in, mi.")},
-				{Contains: newString("consectetur a")},
+			Stdout: &specs.StringAssert{
+				Exactly:  newString("Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nProin nibh augue, suscipit a, scelerisque sed, lacinia in, mi."),
+				Contains: newString("consectetur a"),
 			},
-			Stderr: &[]specs.StringAssert{
-				{Exactly: newString("")},
-			},
-		},
-	}, &StdoutExecutor{})
-
-	shouldFail(t, &specs.BashTest{
-		Expect: &specs.CliExpect{
-			Stdout: &[]specs.StringAssert{
-				{Exactly: newString("Proin nibh augue, suscipit a, scelerisque sed, lacinia in, mi.")},
-				{Contains: newString("consecteturadipiscingadipiscing")},
+			Stderr: &specs.StringAssert{
+				Exactly: newString(""),
 			},
 		},
 	}, &StdoutExecutor{})
 
 	shouldFail(t, &specs.BashTest{
 		Expect: &specs.CliExpect{
-			Stdout: &[]specs.StringAssert{
-				{NotContains: newString("Lorem")},
+			Stdout: &specs.StringAssert{
+				Exactly:  newString("Proin nibh augue, suscipit a, scelerisque sed, lacinia in, mi."),
+				Contains: newString("consecteturadipiscingadipiscing"),
+			},
+		},
+	}, &StdoutExecutor{})
+
+	shouldFail(t, &specs.BashTest{
+		Expect: &specs.CliExpect{
+			Stdout: &specs.StringAssert{
+				NotContains: newString("Lorem"),
 			},
 		},
 	}, &StdoutExecutor{})


### PR DESCRIPTION
Keeping the API of BashTest consistent with the rest.
For any more complex assertion, we can add more conditions,
such as `satisfyingExpression: <string expression>`.

#268 