### PR TITLE
Fix gcloud command

### DIFF
--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -64,7 +64,7 @@ Two workarounds before running the command below:
 Then execute the following.
 
   ```
-  gcloud container builds submit --config cloudbuild.yaml .
+  gcloud builds submit --config cloudbuild.yaml .
   ```
 
 This publishes a `testrunner` container in your project (i.e.


### PR DESCRIPTION
ERROR: (gcloud.container.builds.submit) This command has been replaced with `gcloud builds`.