### PR TITLE
Only overwrite gcloud command if it exists

### DIFF
--- a/marketplace/dev/bin/setup_config.sh
+++ b/marketplace/dev/bin/setup_config.sh
@@ -28,7 +28,7 @@ if [[ -e "/mount/config/.kube/config" ]]; then
     | jq \
           --arg gcloud "$(readlink -f "$(which gcloud)")" \
           '.users = [ .users[] |
-                      if .user["auth-provider"]["name"] == "gcp"
+                      if .user["auth-provider"]["name"] == "gcp" and .user["auth-provider"]["config"]["cmd-path"]
                         then .user["auth-provider"]["config"]["cmd-path"] = $gcloud
                         else .
                       end


### PR DESCRIPTION
Application default credential config does not have
cmd-path set. The old code incorrectly set a new cmd-path,
which would make credential refreshing fail.