### PR TITLE
Fail deployer if config errors

### DIFF
--- a/marketplace/deployer_helm_base/create_manifests.sh
+++ b/marketplace/deployer_helm_base/create_manifests.sh
@@ -72,6 +72,13 @@ if [[ "$mode" = "test" ]]; then
     --test_manifest "$test_data_dir/extracted"
 fi
 
+# Log information and, at the same time, catch errors early and separately.
+# This is a work around for the fact that process and command substitutions
+# do not propagate errors.
+echo "=== values.yaml ==="
+/bin/print_config.py --output=yaml
+echo "==================="
+
 # Run helm expansion.
 for chart in "$data_dir/extracted"/*; do
   chart_manifest_file=$(basename "$chart" | sed 's/.tar.gz$//').yaml

--- a/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
@@ -23,6 +23,14 @@ app_api_version=$(kubectl get "applications/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.apiVersion}')
 
+# Log information and, at the same time, catch errors early and separately.
+# This is a work around for the fact that process and command substitutions
+# do not propagate errors.
+echo -n "Application UID: " && print_config.py --xtype APPLICATION_UID --key true && echo ""
+echo "=== values.yaml ==="
+/bin/print_config.py --output=yaml
+echo "==================="
+
 for chart in /data/chart/*; do
   # Expand and apply the template for the Application resource.
   # Note: This must be done out-of-band because the Application resource

--- a/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
@@ -28,7 +28,7 @@ app_api_version=$(kubectl get "applications/$NAME" \
 # do not propagate errors.
 echo -n "Application UID: " && print_config.py --xtype APPLICATION_UID --key true && echo ""
 echo "=== values.yaml ==="
-/bin/print_config.py --output=yaml
+print_config.py --output=yaml
 echo "==================="
 
 for chart in /data/chart/*; do

--- a/marketplace/deployer_util/print_config_test.py
+++ b/marketplace/deployer_util/print_config_test.py
@@ -54,11 +54,11 @@ class PrintConfigTest(unittest.TestCase):
         'propertyInt': 1,
         'propertyString': 'unnested',
         'dotted.propertyInt': 2,
-        'dotted.propertyString': 'nested_1',
-        'double.propertyInt': 3,
-        'double.propertyString': 'nested_2',
-        'double.dotted.propertyInt': 4,
-        'double.dotted.propertyString': 'double_nested_1'
+        'dotted.propertyString': 'nested',
+        'dotted.dotted.propertyInt': 3,
+        'dotted.dotted.propertyString': 'double_nested',
+        'dotted.dotted.dotted.propertyInt': 4,
+        'dotted.dotted.dotted.propertyString': 'triple_nested',
     }
     actual = print_config.output_yaml(values)
     self.assertEquals(
@@ -67,14 +67,14 @@ class PrintConfigTest(unittest.TestCase):
             'propertyString': 'unnested',
             'dotted': {
                 'propertyInt': 2,
-                'propertyString': 'nested_1'
-            },
-            'double': {
-                'propertyInt': 3,
-                'propertyString': 'nested_2',
+                'propertyString': 'nested',
                 'dotted': {
-                    'propertyInt': 4,
-                    'propertyString': 'double_nested_1'
+                    'propertyInt': 3,
+                    'propertyString': 'double_nested',
+                    'dotted': {
+                        'propertyInt': 4,
+                        'propertyString': 'triple_nested',
+                    },
                 },
             }
         })


### PR DESCRIPTION
Command and process substitution failures do not propagate to the calling script.

I considered (1) using variable for command substitution, which doesn't work either, and (2) writing processing substitution outputs to temporary files. I settled on this as it achieves the same result, and as the same time prints out useful diagnosis log messages.