### PR TITLE
Add docker gcr configuration to dev image build.

### DIFF
--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     apt-get -y update && \
     apt-get -y install docker-ce=17.12.0~ce-0~ubuntu
 
-RUN docker-credential-gcr configure-docker
+RUN gcloud auth configure-docker
 
 COPY marketplace/deployer_util/* /bin/
 COPY scripts/* /scripts/

--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -28,6 +28,8 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     apt-get -y update && \
     apt-get -y install docker-ce=17.12.0~ce-0~ubuntu
 
+RUN docker-credential-gcr configure-docker
+
 COPY marketplace/deployer_util/* /bin/
 COPY scripts/* /scripts/
 COPY marketplace/dev/bin/* /bin/


### PR DESCRIPTION
This ensures that docker client run from within the dev container will
call gcloud to handle authentication/authorization handshake.