### PR TITLE
Update app-crd.yaml.

### DIFF
--- a/crd/app-crd.yaml
+++ b/crd/app-crd.yaml
@@ -16,8 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    api: default
-    kubebuilder.k8s.io: 0.1.10
+    controller-tools.k8s.io: "1.0"
   name: applications.app.k8s.io
 spec:
   group: app.k8s.io
@@ -35,61 +34,30 @@ spec:
         metadata:
           type: object
         spec:
-          type: object
           properties:
-            selector:
-              type: object
             assemblyPhase:
               type: string
             componentKinds:
               items:
                 type: object
               type: array
-            description:
-              type: string
-            info:
-              items:
-                properties:
-                  name:
-                    type: string
-                  type:
-                    type: string
-                  value:
-                    type: string
-                  valueFrom:
+            descriptor:
+              properties:
+                description:
+                  type: string
+                icons:
+                  items:
                     properties:
-                      configMapKeyRef:
-                        properties:
-                          key:
-                            type: string
-                        type: object
-                      ingressRef:
-                        properties:
-                          host:
-                            type: string
-                          path:
-                            type: string
-                        type: object
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                        type: object
-                      serviceRef:
-                        properties:
-                          path:
-                            type: string
-                          port:
-                            type: int32
-                        type: object
+                      size:
+                        type: string
+                      src:
+                        type: string
                       type:
                         type: string
+                    required:
+                    - src
                     type: object
-                type: object
-              type: array
-            descriptor:
-              type: object
-              properties:
+                  type: array
                 keywords:
                   items:
                     type: string
@@ -118,21 +86,130 @@ spec:
                   type: string
                 owners:
                   items:
-                    type: string
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      url:
+                        type: string
+                    type: object
                   type: array
                 type:
                   type: string
                 version:
                   type: string
+              type: object
+            info:
+              items:
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  value:
+                    type: string
+                  valueFrom:
+                    properties:
+                      configMapKeyRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          key:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      ingressRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          host:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          path:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      secretKeyRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          key:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      serviceRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          path:
+                            type: string
+                          port:
+                            format: int32
+                            type: integer
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                type: object
+              type: array
+            selector:
+              type: object
+          type: object
         status:
           properties:
             observedGeneration:
-              type: int64
+              format: int64
+              type: integer
           type: object
-      type: object
   version: v1beta1
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Updated to match https://github.com/kubernetes-sigs/application/blob/master/config/crds/app_v1beta1_application.yaml.

Existing `app-crd.yaml` fails to install into newest cluster version with the following validation exception message:

```
$ kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
error: error validating "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml": error validating data: [ValidationError(CustomResourceDefinition.status): missing required field "conditions" in io.k8s.apiextensions-apiserv
er.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus, ValidationError(CustomResourceDefinition.status): missing required field "storedVersions" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus]; if you choose to i
gnore these errors, turn validation off with --validate=false

```