### PR TITLE
Fix index.yaml update in cloudbuild.yaml and cloudbuild-tag.yaml.

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -42,7 +42,6 @@ steps:
 
     gsutil cp gs://$PROJECT_ID/charts/index.yaml index.yaml
     helm repo index --merge index.yaml charts-tgz/
-    cp index.yaml charts-tgz/index.yaml
 
 images:
 - gcr.io/$PROJECT_ID/k8s/dev:$TAG_NAME

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -142,7 +142,6 @@ steps:
 
     gsutil cp gs://$PROJECT_ID-charts/index.yaml index.yaml
     helm repo index --merge index.yaml charts-tgz/
-    cp index.yaml charts-tgz/index.yaml
 
 - id: &InitializeCredentials Initialize Credentials
   name: gcr.io/cloud-builders/gcloud


### PR DESCRIPTION
Turns out that `index.yaml` in the directory (rather than the merge file) is updated.

Honestly, I'm unclear as to how the helm/charts repository works, given [this](https://github.com/helm/charts/blob/master/test/repo-sync.sh#L90) line.