### PR TITLE
Fix crash in set_ownership.py when resource has no metadata

### DIFF
--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -111,8 +111,9 @@ def dump(outfile, resources, included_kinds, app_name, app_uid,
   to_be_dumped = []
   for resource in resources:
     if included_kinds is None or resource["kind"] in included_kinds:
-      log("Application '{:s}' owns '{:s}/{:s}'".format(
-          app_name, resource["kind"], resource["metadata"]["name"]))
+      name = resource["metadata"]["name"] if "metadata" in resource else None
+      log("Application '{:s}' owns '{:s}/{:s}'".format(app_name,
+                                                       resource["kind"], name))
       resource = copy.deepcopy(resource)
       set_resource_ownership(
           app_uid=app_uid,


### PR DESCRIPTION
The `log()` call would attempt to log `resource["metadata"]["name"]`, which would crash if the resource had no metadata. Now, it will print "None" for the name instead.