### PR TITLE
Support boolean application create property

### DIFF
--- a/marketplace/deployer_helm_tiller_base/bin/deploy.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/deploy.sh
@@ -48,12 +48,6 @@ NAMESPACE="$(/bin/print_config.py \
 export NAME
 export NAMESPACE
 
-app_uid=$(kubectl get "applications/$NAME" \
-  --namespace="$NAMESPACE" \
-  --output=jsonpath='{.metadata.uid}')
-
-/bin/expand_config.py --values_mode=raw --app_uid="$app_uid"
-
 bin/deploy_internal.sh
 
 patch_assembly_phase.sh --status="Success"

--- a/marketplace/deployer_helm_tiller_base/bin/deploy.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/deploy.sh
@@ -48,7 +48,7 @@ NAMESPACE="$(/bin/print_config.py \
 export NAME
 export NAMESPACE
 
-bin/deploy_internal.sh
+/bin/deploy_internal.sh
 
 patch_assembly_phase.sh --status="Success"
 

--- a/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
@@ -26,6 +26,7 @@ app_api_version=$(kubectl get "applications/$NAME" \
 # Log information and, at the same time, catch errors early and separately.
 # This is a work around for the fact that process and command substitutions
 # do not propagate errors.
+/bin/expand_config.py --values_mode=raw --app_uid="$app_uid"
 echo -n "Application UID: " && print_config.py --xtype APPLICATION_UID --key true && echo ""
 echo "=== values.yaml ==="
 print_config.py --output=yaml
@@ -36,11 +37,11 @@ for chart in /data/chart/*; do
   # Note: This must be done out-of-band because the Application resource
   # is created before the deployer is invoked, but helm does not handle
   # pre-existing resources.
+  /bin/expand_config.py --values_mode=raw --app_uid=""
   helm template \
       --name="$NAME" \
       --namespace="$NAMESPACE" \
       --values=<(print_config.py --output=yaml) \
-      --set "$(print_config.py --xtype APPLICATION_UID --key true)=" \
       "$chart" \
     | yaml2json \
     | jq 'select( .kind == "Application" )' \
@@ -52,6 +53,7 @@ for chart in /data/chart/*; do
   # hook processing.
   # Note: The local tiller process is configured with --storage=secret,
   # which is recommended but not default behavior.
+  /bin/expand_config.py --values_mode=raw --app_uid="$app_uid"
   helm tiller run "$NAMESPACE" -- \
     helm install \
         --name="$NAME" \

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -165,6 +165,7 @@ class SchemaProperty:
     self._required = required
     self._default = dictionary.get('default', None)
     self._x = dictionary.get(XGOOGLE, None)
+    self._application_uid = None
     self._image = None
     self._password = None
     self._reporting_secret = None
@@ -197,9 +198,11 @@ class SchemaProperty:
         raise InvalidSchema('Property {} has {} without a type'.format(
             name, XGOOGLE))
       xt = self._x['type']
-      if xt in (XTYPE_NAME, XTYPE_NAMESPACE, XTYPE_APPLICATION_UID,
-                XTYPE_DEPLOYER_IMAGE):
+      if xt in (XTYPE_NAME, XTYPE_NAMESPACE, XTYPE_DEPLOYER_IMAGE):
         pass
+      elif xt == XTYPE_APPLICATION_UID:
+        d = self._x.get('applicationUid', {})
+        self._application_uid = SchemaXApplicationUid(d)
       elif xt == XTYPE_IMAGE:
         d = self._x.get('image', {})
         self._image = SchemaXImage(d)
@@ -249,6 +252,10 @@ class SchemaProperty:
     if self._x:
       return self._x['type']
     return None
+
+  @property
+  def application_uid(self):
+    return self._application_uid
 
   @property
   def image(self):
@@ -314,6 +321,19 @@ class SchemaProperty:
     if not isinstance(other, SchemaProperty):
       return False
     return other._name == self._name and other._d == self._d
+
+
+class SchemaXApplicationUid:
+  """Wrapper class providing convenient access to APPLICATION_UID properties."""
+
+  def __init__(self, dictionary):
+    generated_properties = dictionary.get('generatedProperties', {})
+    self._application_create = generated_properties.get(
+        'createApplicationBoolean', None)
+
+  @property
+  def application_create(self):
+    return self._application_create
 
 
 class SchemaXImage:

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -201,6 +201,32 @@ class ConfigHelperTest(unittest.TestCase):
         """)
     self.assertIsNotNone(schema.properties['ns'])
 
+  def test_application_uid_type(self):
+    schema = config_helper.Schema.load_yaml("""
+        properties:
+          u:
+            type: string
+            x-google-marketplace:
+              type: APPLICATION_UID
+        """)
+    self.assertIsNotNone(schema.properties['u'].application_uid)
+    self.assertIsNone(schema.properties['u'].application_uid.application_create)
+
+  def test_application_uid_type_create_application(self):
+    schema = config_helper.Schema.load_yaml("""
+        properties:
+          u:
+            type: string
+            x-google-marketplace:
+              type: APPLICATION_UID
+              applicationUid:
+                generatedProperties:
+                  createApplicationBoolean: application.create
+        """)
+    self.assertIsNotNone(schema.properties['u'].application_uid)
+    self.assertEqual('application.create',
+                     schema.properties['u'].application_uid.application_create)
+
   def test_image_type(self):
     schema = config_helper.Schema.load_yaml("""
         properties:
@@ -483,16 +509,6 @@ class ConfigHelperTest(unittest.TestCase):
               type: REPORTING_SECRET
         """)
     self.assertIsNotNone(schema.properties['rs'].reporting_secret)
-
-  def test_application_uid_type(self):
-    schema = config_helper.Schema.load_yaml("""
-        properties:
-          u:
-            type: string
-            x-google-marketplace:
-              type: APPLICATION_UID
-        """)
-    self.assertIsNotNone(schema.properties['u'])
 
   def test_unknown_type(self):
     self.assertRaises(

--- a/marketplace/deployer_util/expand_config.py
+++ b/marketplace/deployer_util/expand_config.py
@@ -46,7 +46,7 @@ def main():
       default='/data/final_values.yaml')
   parser.add_argument(
       '--app_uid',
-      help='The application UID for populating into APPLICATION_UID properties.',
+      help='The application UID for populating into APPLICATION_UID properties',
       default='')
   args = parser.parse_args()
 
@@ -76,12 +76,9 @@ def expand(values_dict, schema, app_uid=''):
       result[k] = generate_password(prop.password)
       continue
 
-    if v is None and prop.xtype == 'APPLICATION_UID':
-      if not app_uid:
-        raise InvalidProperty(
-            'Property {} is of type APPLICATION_UID, but --app_uid was not '
-            'specified.'.format(k, v))
-      result[k] = app_uid
+    if v is None and prop.application_uid:
+      result[k] = app_uid or ''
+      generate_properties_for_appuid(prop, app_uid, generated)
       continue
 
     if v is None and prop.default is not None:
@@ -128,6 +125,11 @@ def validate_value_types(values, schema):
       raise InvalidProperty(
           'Property {} is expected to be of type {}, but has value: {}'.format(
               k, prop.type, v))
+
+
+def generate_properties_for_appuid(prop, value, result):
+  if prop.application_uid.application_create:
+    result[prop.application_uid.application_create] = False if value else True
 
 
 def generate_properties_for_image(prop, value, result):

--- a/marketplace/deployer_util/expand_config_test.py
+++ b/marketplace/deployer_util/expand_config_test.py
@@ -135,24 +135,20 @@ class ExpandConfigTest(unittest.TestCase):
             type: string
             x-google-marketplace:
               type: APPLICATION_UID
+              applicationUid:
+                generatedProperties:
+                  createApplicationBoolean: application.create
         """)
     result = expand_config.expand({}, schema, app_uid='1234-abcd')
-    self.assertEqual({'application_uid': '1234-abcd'}, result)
-
-  def test_application_uid_raises_when_unspecified(self):
-    schema = config_helper.Schema.load_yaml("""
-        applicationApiVersion: v1beta1
-        properties:
-          application_uid:
-            type: string
-            x-google-marketplace:
-              type: APPLICATION_UID
-        """)
-    self.assertRaises(
-        expand_config.InvalidProperty,
-        expand_config.expand, {},
-        schema,
-        app_uid=None)
+    self.assertEqual({
+        'application_uid': '1234-abcd',
+        'application.create': False
+    }, result)
+    result = expand_config.expand({}, schema, app_uid='')
+    self.assertEqual({
+        'application_uid': '',
+        'application.create': True
+    }, result)
 
   def test_write_values(self):
     schema = config_helper.Schema.load_yaml("""

--- a/tests/marketplace/deployer_helm_tiller_base/onbuild/standard/chart/minimal-helm-chart/templates/application.yaml
+++ b/tests/marketplace/deployer_helm_tiller_base/onbuild/standard/chart/minimal-helm-chart/templates/application.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.application_uid }}
+{{- if .Values.global.application.create }}
 
 apiVersion: app.k8s.io/v1beta1
 kind: Application

--- a/tests/marketplace/deployer_helm_tiller_base/onbuild/standard/schema.yaml
+++ b/tests/marketplace/deployer_helm_tiller_base/onbuild/standard/schema.yaml
@@ -12,6 +12,9 @@ properties:
     type: string
     x-google-marketplace:
       type: APPLICATION_UID
+      applicationUid:
+        generatedProperties:
+          createApplicationBoolean: global.application.create
   marketplace-integration.image:
     type: string
     x-google-marketplace:


### PR DESCRIPTION
Some helm charts wish to use global.application.create value
to control whether the Application resource should be included
in the generated manifests. This is the negation of the truthy
value of the existing APPLICATION_UID property.