### PR TITLE
Improve Ingress readiness

### DIFF
--- a/marketplace/deployer_util/wait_for_ready.py
+++ b/marketplace/deployer_util/wait_for_ready.py
@@ -16,6 +16,7 @@
 
 import sys
 import time
+import json
 
 from argparse import ArgumentParser
 from bash_util import Command
@@ -178,8 +179,12 @@ def is_service_ready(resource):
 
 
 def is_ingress_ready(resource):
-  if 'ingress' in resource['status']['loadBalancer']:
-    return True
+  for key, value in annotations(resource).items():
+    if key == 'ingress.kubernetes.io/backends':
+      data = json.loads(value)
+      status = list(data.values())[0]
+      if status == "HEALTHY":
+        return True
 
   log("INFO Ingress/{} is not ready.".format(name(resource)))
   return False
@@ -198,6 +203,10 @@ def name(resource):
 
 def labels(resource):
   return resource['metadata']['labels']
+
+
+def annotations(resource):
+  return resource['metadata']['annotations']
 
 
 def total_replicas(resource):

--- a/marketplace/deployer_util/wait_for_ready.py
+++ b/marketplace/deployer_util/wait_for_ready.py
@@ -183,7 +183,7 @@ def is_ingress_ready(resource):
     if key == 'ingress.kubernetes.io/backends':
       data = json.loads(value)
       status = list(data.values())[0]
-      if status == "HEALTHY":
+      if status == 'HEALTHY':
         return True
 
   log("INFO Ingress/{} is not ready.".format(name(resource)))


### PR DESCRIPTION
Checking Ingress's readiness is more difficult. Even if the IP address is available, it doesn't mean that the ingress is ready. We should wait for annotations instead.

Not ready ingress:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"extensions/v1beta1","kind":"Ingress","
...
```

Ready ingress:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    ingress.kubernetes.io/backends: '{"k8s-be-32534--85c24f04c12b3680":"HEALTHY"}'
    ingress.kubernetes.io/forwarding-rule: k8s-fw-wgrzelak-wp-22768-wordpress-ingress--85c24f04c12b3680
    ingress.kubernetes.io/https-forwarding-rule: k8s-fws-wgrzelak-wp-22768-wordpress-ingress--85c24f04c12b3680
...
```