### PR TITLE
Use full app CRD resource name

### DIFF
--- a/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/deploy_internal.sh
@@ -16,10 +16,10 @@
 
 set -eox pipefail
 
-app_uid=$(kubectl get "applications/$NAME" \
+app_uid=$(kubectl get "applications.app.k8s.io/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.metadata.uid}')
-app_api_version=$(kubectl get "applications/$NAME" \
+app_api_version=$(kubectl get "applications.app.k8s.io/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.apiVersion}')
 

--- a/marketplace/deployer_helm_tiller_base/bin/post-delete.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/post-delete.sh
@@ -37,4 +37,4 @@ done
 [[ -z "$name" ]] && >&2 echo "--name required" && exit 1
 [[ -z "$namespace" ]] && >&2 echo "--namespace required" && exit 1
 
-kubectl delete "applications/$name"
+kubectl delete "applications.app.k8s.io/$name"

--- a/marketplace/deployer_helm_tiller_base/bin/post-install.sh
+++ b/marketplace/deployer_helm_tiller_base/bin/post-install.sh
@@ -37,13 +37,13 @@ done
 [[ -z "$name" ]] && >&2 echo "--name required" && exit 1
 [[ -z "$namespace" ]] && >&2 echo "--namespace required" && exit 1
 
-app_uid="$(kubectl get "applications/$name" \
+app_uid="$(kubectl get "applications.app.k8s.io/$name" \
     --namespace="$namespace" \
     --output=jsonpath='{.metadata.uid}')"
-app_api_version="$(kubectl get "applications/$name" \
+app_api_version="$(kubectl get "applications.app.k8s.io/$name" \
     --namespace="$namespace" \
     --output=jsonpath='{.apiVersion}')"
-component_kinds="$(kubectl get "applications/$name" \
+component_kinds="$(kubectl get "applications.app.k8s.io/$name" \
     --namespace="$namespace" \
     --output=json \
   | jq -r '.spec.componentKinds[]

--- a/marketplace/deployer_util/deploy.sh
+++ b/marketplace/deployer_util/deploy.sh
@@ -50,10 +50,10 @@ export NAMESPACE
 
 echo "Deploying application \"$NAME\""
 
-app_uid=$(kubectl get "applications/$NAME" \
+app_uid=$(kubectl get "applications.app.k8s.io/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.metadata.uid}')
-app_api_version=$(kubectl get "applications/$NAME" \
+app_api_version=$(kubectl get "applications.app.k8s.io/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.apiVersion}')
 

--- a/marketplace/deployer_util/deploy_with_tests.sh
+++ b/marketplace/deployer_util/deploy_with_tests.sh
@@ -34,10 +34,10 @@ export NAMESPACE
 
 echo "Deploying application \"$NAME\" in test mode"
 
-app_uid=$(kubectl get "applications/$NAME" \
+app_uid=$(kubectl get "applications.app.k8s.io/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.metadata.uid}')
-app_api_version=$(kubectl get "applications/$NAME" \
+app_api_version=$(kubectl get "applications.app.k8s.io/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.apiVersion}')
 

--- a/marketplace/deployer_util/patch_assembly_phase.sh
+++ b/marketplace/deployer_util/patch_assembly_phase.sh
@@ -45,7 +45,7 @@ echo "Marking deployment of application \"$NAME\" as \"$status\"."
 
 # --output=json is used to force kubectl to succeed even if the patch command
 # makes not change to the resource. Otherwise, this command exits 1.
-kubectl patch "applications/$NAME" \
+kubectl patch "applications.app.k8s.io/$NAME" \
   --output=json \
   --namespace="$NAMESPACE" \
   --type=merge \

--- a/marketplace/deployer_util/wait_for_ready.py
+++ b/marketplace/deployer_util/wait_for_ready.py
@@ -39,7 +39,7 @@ def main():
 
   application = Command(
       '''
-    kubectl get "applications/{}"
+    kubectl get "applications.app.k8s.io/{}"
       --namespace="{}"
       --output=json
     '''.format(args.name, args.namespace),
@@ -73,7 +73,7 @@ def main():
         break
 
     if previous_healthy != healthy:
-      log("INFO Initialization: Found applications/{} ready status to be {}."
+      log("INFO Initialization: Found applications.app.k8s.io/{} ready status to be {}."
           .format(args.name, healthy))
       previous_healthy = healthy
       if healthy:

--- a/scripts/install
+++ b/scripts/install
@@ -76,7 +76,7 @@ spec:
   assemblyPhase: "Pending"
 EOF
 
-app_uid=$(kubectl get "applications/$name" \
+app_uid=$(kubectl get "applications.app.k8s.io/$name" \
   --namespace="$namespace" \
   --output=jsonpath='{.metadata.uid}')
 

--- a/scripts/verify
+++ b/scripts/verify
@@ -152,7 +152,7 @@ deletion_timeout=180
 echo "INFO Wait for the applications to be deleted"
 /scripts/wait_for_deletion.sh \
   --namespace="$NAMESPACE" \
-  --kind=applications \
+  --kind=applications.app.k8s.io \
   --timeout="$deletion_timeout" \
   || clean_and_exit "ERROR Some applications where not deleted"
 

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -43,9 +43,9 @@ function watch_function() {
   # TODO(trironkk): Extract printing and then running a command into a function.
   print_bar =
   echo "Application resources in the following namespace: \"$namespace\""
-  echo "$ kubectl get applications --namespace=\"$namespace\" --show-kind"
+  echo "$ kubectl get applications.app.k8s.io --namespace=\"$namespace\" --show-kind"
   print_bar -
-  kubectl get applications \
+  kubectl get applications.app.k8s.io \
       --namespace="$namespace" \
       --show-kind
 


### PR DESCRIPTION
Use `applications.app.k8s.io` instead of the short name for the applications CRD.

This hardens the tooling for environments where there might be a conflict on 
the `applications` short name and some other API group is prioritized by Kubernetes
discovery.

Fixes #321 