### PR TITLE
 Adding istio types in schema files

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -363,6 +363,7 @@ properties:
             resources: ['EtcdCluster']
             verbs: ['*']
 ```
+
 ---
 
 ### type: STORAGE_CLASS
@@ -380,6 +381,8 @@ properties:
       storageClass:
         type: SSD
 ```
+
+---
 
 ### type: STRING
 
@@ -399,6 +402,41 @@ properties:
 ```
 
 In the example above, manifests can reference to the password as `explicitPassword`, as well as to its base64Encoded value as `explicitPasswordEncoded`.
+
+---
+
+### type: ISTIO_ENABLED
+
+This used to tell the deployer whether Istio is enabled or not. That information is used by manifests to provision special handling to work with Istio.
+
+### Supported values
+- `True`: Istio is not enabled.
+- `False`: Istio is enabled.
+
+If `ISTIO_ENABLED` is not preset, it is assumed Istio is not enabled for the deployment.
+
+---
+
+## istioCompatibility
+
+Nested under `x-google-marketplace`, this indicates whether the application is compatible with Istio.
+
+### Supported values
+- `True`: The app is compatible with Istio.
+- `False`: The app is NOT compatible with Istio.
+
+```yaml
+properties:
+  # Property definitions...
+required:
+  # Required properties...
+x-google-marketplace:
+  istioCompatibility: True # or False
+```
+
+If `istioCompatibility` is not present, it is assumed that it is unknown whether the app is compatible with Istio or not.
+
+---
 
 ## clusterConstraints
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -260,6 +260,7 @@ It defines how this object will be handled. Each type has a different set of pro
 - `STORAGE_CLASS`: The name of a pre-provisioned k8s `StorageClass`. If it does not exist, one is created.
 - `STRING`: A string that needs special handling.
 - `APPLICATION_UID`: The uuid of the created `Application` object.
+- `ISTIO_ENABLED`: Indicates whether Istio is enabled for the deployement.
 
 ---
 
@@ -407,23 +408,15 @@ In the example above, manifests can reference to the password as `explicitPasswo
 
 ### type: ISTIO_ENABLED
 
-This used to tell the deployer whether Istio is enabled or not. That information is used by manifests to provision special handling to work with Istio.
+This boolean property receives a True value if the environment is detected to have Istio enabled, and False otherwise. The deployer and template can take this signal to adapt the deployment accordingly.
 
-### Supported values
-- `True`: Istio is not enabled.
-- `False`: Istio is enabled.
-
-If `ISTIO_ENABLED` is not preset, it is assumed Istio is not enabled for the deployment.
+If `ISTIO_ENABLED` is not present, it is assumed Istio is NOT enabled for the deployment.
 
 ---
 
-## istioCompatible
+## istio
 
-Nested under `x-google-marketplace`, this indicates whether the application is compatible with Istio.
-
-### Supported values
-- `True`: The app is compatible with Istio.
-- `False`: The app is NOT compatible with Istio.
+Nested under `x-google-marketplace`, it holds information about compatibility between the app and the Istio service mesh.
 
 ```yaml
 properties:
@@ -431,10 +424,16 @@ properties:
 required:
   # Required properties...
 x-google-marketplace:
-  istioCompatible: True # or False
+  istio:
+    isSupported: True 
 ```
 
-If `istioCompatible` is not present, it is assumed that it is unknown whether the app is compatible with Istio or not.
+---
+
+### isSupported
+
+This boolean property receives a True value if the application is compatible with Istio, and False otherwise.
+If `isSupported` is not present, it is assumed that it is unknown whether the app supports Istio or not.
 
 ---
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -417,7 +417,7 @@ If `ISTIO_ENABLED` is not preset, it is assumed Istio is not enabled for the dep
 
 ---
 
-## istioCompatibility
+## istioCompatible
 
 Nested under `x-google-marketplace`, this indicates whether the application is compatible with Istio.
 
@@ -431,10 +431,10 @@ properties:
 required:
   # Required properties...
 x-google-marketplace:
-  istioCompatibility: True # or False
+  istioCompatible: True # or False
 ```
 
-If `istioCompatibility` is not present, it is assumed that it is unknown whether the app is compatible with Istio or not.
+If `istioCompatible` is not present, it is assumed that it is unknown whether the app is compatible with Istio or not.
 
 ---
 

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -185,6 +185,7 @@ class SchemaXGoogleMarketplace:
     self._published_version_meta = None
     self._images = None
     self._cluster_constraints = None
+    self._istio_compatible = None
 
     self._schema_version = dictionary.get('schemaVersion', _SCHEMA_VERSION_1)
     if self._schema_version not in _SCHEMA_VERSIONS:
@@ -194,6 +195,9 @@ class SchemaXGoogleMarketplace:
     if 'clusterConstraints' in dictionary:
       self._cluster_constraints = SchemaClusterConstraints(
           dictionary['clusterConstraints'])
+
+    if 'istioCompatible' in dictionary:
+      self._istio_compatible = dictionary['istioCompatible']
 
     if not self.is_v2():
       return
@@ -218,6 +222,10 @@ class SchemaXGoogleMarketplace:
   @property
   def cluster_constraints(self):
     return self._cluster_constraints
+
+  @property
+  def istio_compatible(self):
+    return self._istio_compatible
 
   @property
   def app_api_version(self):

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -453,7 +453,8 @@ class SchemaProperty:
     if self._x:
       xt = _must_get(self._x, 'type',
                      'Property {} has {} without a type'.format(name, XGOOGLE))
-      if xt in (XTYPE_NAME, XTYPE_NAMESPACE, XTYPE_DEPLOYER_IMAGE, XTYPE_ISTIO_ENABLED):
+      if xt in (XTYPE_NAME, XTYPE_NAMESPACE, XTYPE_DEPLOYER_IMAGE,
+                XTYPE_ISTIO_ENABLED):
         pass
       elif xt == XTYPE_APPLICATION_UID:
         d = self._x.get('applicationUid', {})

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -349,9 +349,6 @@ class SchemaIstio:
   def __init__(self, dictionary):
     self._is_supported = dictionary.get('isSupported', None)
 
-    if 'isSupported' in dictionary:
-      self._is_supported = dictionary['isSupported']
-
   @property
   def is_supported(self):
     return self._is_supported

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -35,6 +35,7 @@ XTYPE_SERVICE_ACCOUNT = 'SERVICE_ACCOUNT'
 XTYPE_STORAGE_CLASS = 'STORAGE_CLASS'
 XTYPE_STRING = 'STRING'
 XTYPE_APPLICATION_UID = 'APPLICATION_UID'
+XTYPE_ISTIO_ENABLED = 'ISTIO_ENABLED'
 
 WIDGET_TYPES = ['help']
 
@@ -428,6 +429,7 @@ class SchemaProperty:
     self._service_account = None
     self._storage_class = None
     self._string = None
+    self._istio_enabled = None
 
     if not NAME_RE.match(name):
       raise InvalidSchema('Invalid property name: {}'.format(name))
@@ -451,7 +453,7 @@ class SchemaProperty:
     if self._x:
       xt = _must_get(self._x, 'type',
                      'Property {} has {} without a type'.format(name, XGOOGLE))
-      if xt in (XTYPE_NAME, XTYPE_NAMESPACE, XTYPE_DEPLOYER_IMAGE):
+      if xt in (XTYPE_NAME, XTYPE_NAMESPACE, XTYPE_DEPLOYER_IMAGE, XTYPE_ISTIO_ENABLED):
         pass
       elif xt == XTYPE_APPLICATION_UID:
         d = self._x.get('applicationUid', {})

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -185,7 +185,7 @@ class SchemaXGoogleMarketplace:
     self._published_version_meta = None
     self._images = None
     self._cluster_constraints = None
-    self._istio_compatible = None
+    self._istio = None
 
     self._schema_version = dictionary.get('schemaVersion', _SCHEMA_VERSION_1)
     if self._schema_version not in _SCHEMA_VERSIONS:
@@ -196,8 +196,8 @@ class SchemaXGoogleMarketplace:
       self._cluster_constraints = SchemaClusterConstraints(
           dictionary['clusterConstraints'])
 
-    if 'istioCompatible' in dictionary:
-      self._istio_compatible = dictionary['istioCompatible']
+    if 'istio' in dictionary:
+      self._istio = SchemaIstio(dictionary['istio'])
 
     if not self.is_v2():
       return
@@ -224,8 +224,8 @@ class SchemaXGoogleMarketplace:
     return self._cluster_constraints
 
   @property
-  def istio_compatible(self):
-    return self._istio_compatible
+  def istio(self):
+    return self._istio
 
   @property
   def app_api_version(self):
@@ -341,6 +341,20 @@ class SchemaResourceConstraintRequests:
   @property
   def memory(self):
     return self._memory
+
+
+class SchemaIstio:
+  """Accesses top level istio."""
+
+  def __init__(self, dictionary):
+    self._is_supported = dictionary.get('isSupported', None)
+
+    if 'isSupported' in dictionary:
+      self._is_supported = dictionary['isSupported']
+
+  @property
+  def is_supported(self):
+    return self._is_supported
 
 
 class SchemaImage:

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -644,8 +644,7 @@ class ConfigHelperTest(unittest.TestCase):
             isSupported: True
         """)
     schema.validate()
-    self.assertEqual(
-        schema.x_google_marketplace.istio.is_supported, True)
+    self.assertEqual(schema.x_google_marketplace.istio.is_supported, True)
 
   def test_validate_good(self):
     schema = config_helper.Schema.load_yaml("""

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -593,6 +593,19 @@ class ConfigHelperTest(unittest.TestCase):
     self.assertEqual(
         schema.x_google_marketplace.cluster_constraints.k8s_version, '>1.11')
 
+  def test_istio_compatible(self):
+    schema = config_helper.Schema.load_yaml("""
+        applicationApiVersion: v1beta1
+        properties:
+          simple:
+            type: string
+        x-google-marketplace:
+          istioCompatible: true
+        """)
+    schema.validate()
+    self.assertEqual(
+        schema.x_google_marketplace.istio_compatible, True)
+
   def test_resource_constraints(self):
     schema = config_helper.Schema.load_yaml("""
         applicationApiVersion: v1beta1

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -593,19 +593,6 @@ class ConfigHelperTest(unittest.TestCase):
     self.assertEqual(
         schema.x_google_marketplace.cluster_constraints.k8s_version, '>1.11')
 
-  def test_istio_compatible(self):
-    schema = config_helper.Schema.load_yaml("""
-        applicationApiVersion: v1beta1
-        properties:
-          simple:
-            type: string
-        x-google-marketplace:
-          istioCompatible: true
-        """)
-    schema.validate()
-    self.assertEqual(
-        schema.x_google_marketplace.istio_compatible, True)
-
   def test_resource_constraints(self):
     schema = config_helper.Schema.load_yaml("""
         applicationApiVersion: v1beta1
@@ -645,6 +632,20 @@ class ConfigHelperTest(unittest.TestCase):
                      'REQUIRE_MINIMUM_NODE_COUNT')
     self.assertEqual(
         resources[1].affinity.simple_node_affinity.minimum_node_count, 4)
+
+  def test_istio(self):
+    schema = config_helper.Schema.load_yaml("""
+        applicationApiVersion: v1beta1
+        properties:
+          simple:
+            type: string
+        x-google-marketplace:
+          istio:
+            isSupported: True
+        """)
+    schema.validate()
+    self.assertEqual(
+        schema.x_google_marketplace.istio.is_supported, True)
 
   def test_validate_good(self):
     schema = config_helper.Schema.load_yaml("""

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -62,6 +62,10 @@ properties:
     type: string
     x-google-marketplace:
       type: APPLICATION_UID
+  istioEnabled:
+    type: boolean
+    x-google-marketplace:
+      type: ISTIO_ENABLED
 required:
 - propertyString
 - propertyPassword
@@ -111,7 +115,7 @@ class ConfigHelperTest(unittest.TestCase):
         'propertyIntegerWithDefault', 'propertyNumber',
         'propertyNumberWithDefault', 'propertyBoolean',
         'propertyBooleanWithDefault', 'propertyImage', 'propertyDeployerImage',
-        'propertyPassword', 'applicationUid'
+        'propertyPassword', 'applicationUid', 'istioEnabled'
     }, set(schema.properties))
     self.assertEqual(str, schema.properties['propertyString'].type)
     self.assertIsNone(schema.properties['propertyString'].default)
@@ -206,16 +210,15 @@ class ConfigHelperTest(unittest.TestCase):
         """)
     self.assertIsNotNone(schema.properties['ns'])
 
-  def test_application_uid_type(self):
+  def test_istio_enabled_type(self):
     schema = config_helper.Schema.load_yaml("""
         properties:
           u:
-            type: string
+            type: boolean
             x-google-marketplace:
-              type: APPLICATION_UID
+              type: ISTIO_ENABLED
         """)
-    self.assertIsNotNone(schema.properties['u'].application_uid)
-    self.assertIsNone(schema.properties['u'].application_uid.application_create)
+    self.assertIsNotNone(schema.properties['u'])
 
   def test_application_uid_type_create_application(self):
     schema = config_helper.Schema.load_yaml("""

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -210,15 +210,16 @@ class ConfigHelperTest(unittest.TestCase):
         """)
     self.assertIsNotNone(schema.properties['ns'])
 
-  def test_istio_enabled_type(self):
+  def test_application_uid_type(self):
     schema = config_helper.Schema.load_yaml("""
         properties:
           u:
-            type: boolean
+            type: string
             x-google-marketplace:
-              type: ISTIO_ENABLED
+              type: APPLICATION_UID
         """)
-    self.assertIsNotNone(schema.properties['u'])
+    self.assertIsNotNone(schema.properties['u'].application_uid)
+    self.assertIsNone(schema.properties['u'].application_uid.application_create)
 
   def test_application_uid_type_create_application(self):
     schema = config_helper.Schema.load_yaml("""


### PR DESCRIPTION
Introducing schema file x-google-marketplace properties:
- Compatibility flag
```yaml
x-google-marketplace:
  istio:
    isSupported: True # Indicates whether the app is compatible with Istio.
```
- Deployer property
```yaml
properties:
- name: istioEnabled
  type: ISTIO_ENABLED # Indicates whether the app is being deployed with Istio.
```