### PR TITLE
Validate default value for IMAGE properties in schema v1

### DIFF
--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -101,8 +101,8 @@ class Schema:
 
   def __init__(self, dictionary):
     self._x_google_marketplace = _maybe_get_and_apply(
-        dictionary,
-        'x-google-marketplace', lambda v: SchemaXGoogleMarketplace(v))
+        dictionary, 'x-google-marketplace',
+        lambda v: SchemaXGoogleMarketplace(v))
 
     self._required = dictionary.get('required', [])
     self._properties = {

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -101,8 +101,8 @@ class Schema:
 
   def __init__(self, dictionary):
     self._x_google_marketplace = _maybe_get_and_apply(
-        dictionary, 'x-google-marketplace',
-        lambda v: SchemaXGoogleMarketplace(v))
+        dictionary,
+        'x-google-marketplace', lambda v: SchemaXGoogleMarketplace(v))
 
     self._required = dictionary.get('required', [])
     self._properties = {
@@ -522,7 +522,7 @@ class SchemaProperty:
       elif xt == XTYPE_IMAGE:
         _property_must_have_type(self, str)
         d = self._x.get('image', {})
-        self._image = SchemaXImage(d)
+        self._image = SchemaXImage(d, self._default)
       elif xt == XTYPE_PASSWORD:
         _property_must_have_type(self, str)
         d = self._x.get('generatedPassword', {})
@@ -669,9 +669,18 @@ class SchemaXApplicationUid:
 class SchemaXImage:
   """Accesses IMAGE and DEPLOYER_IMAGE properties."""
 
-  def __init__(self, dictionary):
+  def __init__(self, dictionary, default):
     self._split_by_colon = None
     self._split_to_registry_repo_tag = None
+
+    if not default:
+      raise InvalidSchema('default image value must be specified')
+    if not default.startswith('gcr.io'):
+      raise InvalidSchema(
+          'default image value must state registry: {}'.format(default))
+    if ':' not in default:
+      raise InvalidSchema(
+          'default image value is missing a tag or digest: {}'.format(default))
 
     generated_properties = dictionary.get('generatedProperties', {})
     if 'splitByColon' in generated_properties:

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -46,7 +46,7 @@ properties:
     default: false
   propertyImage:
     type: string
-    default: gcr.io/google/busybox
+    default: gcr.io/google/busybox:1.0
     x-google-marketplace:
       type: IMAGE
   propertyDeployerImage:
@@ -155,7 +155,7 @@ class ConfigHelperTest(unittest.TestCase):
     self.assertEqual(False,
                      schema.properties['propertyBooleanWithDefault'].default)
     self.assertEqual(str, schema.properties['propertyImage'].type)
-    self.assertEqual('gcr.io/google/busybox',
+    self.assertEqual('gcr.io/google/busybox:1.0',
                      schema.properties['propertyImage'].default)
     self.assertEqual('IMAGE', schema.properties['propertyImage'].xtype)
     self.assertEqual('DEPLOYER_IMAGE',
@@ -191,8 +191,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_invalid_property_types(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type string$',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: integer
@@ -200,8 +200,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: NAME
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type string$',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: number
@@ -209,8 +209,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: NAMESPACE
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type string$',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: int
@@ -218,8 +218,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: DEPLOYER_IMAGE
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type string$',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: boolean
@@ -227,8 +227,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: APPLICATION_UID
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type boolean$',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type boolean$', lambda:
+        config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: string
@@ -236,8 +236,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: ISTIO_ENABLED
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type boolean$',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type boolean$', lambda:
+        config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: string
@@ -313,11 +313,49 @@ class ConfigHelperTest(unittest.TestCase):
     self.assertEqual('application.create',
                      schema.properties['u'].application_uid.application_create)
 
+  def test_image_default_missing(self):
+    self.assertRaisesRegexp(
+        config_helper.InvalidSchema, r'.*default image value must be specified',
+        lambda: config_helper.Schema.load_yaml("""
+        properties:
+          i:
+            type: string
+            x-google-marketplace:
+              type: IMAGE
+        """))
+
+  def test_image_default_missing_repo(self):
+    self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        r'.*default image value must state registry', lambda: config_helper.
+        Schema.load_yaml("""
+        properties:
+          i:
+            type: string
+            default: $REGISTRY/some-repo:some-tag
+            x-google-marketplace:
+              type: IMAGE
+        """))
+
+  def test_image_default_missing_tag_or_digest(self):
+    self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        r'.*default image value is missing a tag or digest', lambda:
+        config_helper.Schema.load_yaml("""
+        properties:
+          i:
+            type: string
+            default: gcr.io/some-repo
+            x-google-marketplace:
+              type: IMAGE
+        """))
+
   def test_image_type(self):
     schema = config_helper.Schema.load_yaml("""
         properties:
           i:
             type: string
+            default: gcr.io/some-repo:some-tag
             x-google-marketplace:
               type: IMAGE
         """)
@@ -330,6 +368,7 @@ class ConfigHelperTest(unittest.TestCase):
         properties:
           i:
             type: string
+            default: gcr.io/some-repo:some-tag
             x-google-marketplace:
               type: IMAGE
               image:
@@ -347,6 +386,7 @@ class ConfigHelperTest(unittest.TestCase):
         properties:
           i:
             type: string
+            default: gcr.io/some-repo:some-tag
             x-google-marketplace:
               type: IMAGE
               image:
@@ -365,6 +405,7 @@ class ConfigHelperTest(unittest.TestCase):
         properties:
           di:
             type: string
+            default: gcr.io/some-repo:some-tag
             x-google-marketplace:
               type: DEPLOYER_IMAGE
         """)
@@ -461,8 +502,8 @@ class ConfigHelperTest(unittest.TestCase):
     self.assertEqual(False, schema.properties['pb'].str_to_type('False'))
     self.assertEqual(False, schema.properties['pb'].str_to_type('no'))
     self.assertEqual(False, schema.properties['pb'].str_to_type('No'))
-    self.assertRaises(config_helper.InvalidValue,
-                      lambda: schema.properties['pb'].str_to_type('bad'))
+    self.assertRaises(config_helper.InvalidValue, lambda: schema.properties[
+        'pb'].str_to_type('bad'))
 
   def test_invalid_default_type(self):
     self.assertRaises(
@@ -809,8 +850,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_missing_app_api_version(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, 'applicationApiVersion',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        'applicationApiVersion', lambda: config_helper.Schema.load_yaml("""
             properties:
               simple:
                 type: string
@@ -818,8 +859,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_too_many_items(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, 'form',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        'form', lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - widget: help
@@ -830,8 +871,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_missing_type(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, 'form',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        'form', lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - description: My arbitrary <i>description</i>
@@ -839,8 +880,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_unrecognized_type(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, 'form',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        'form', lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - widget: magical
@@ -849,8 +890,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_missing_description(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, 'form',
-        lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema,
+        'form', lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - widget: help

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -191,8 +191,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_invalid_property_types(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type string$',
+        lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: integer
@@ -200,8 +200,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: NAME
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type string$',
+        lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: number
@@ -209,8 +209,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: NAMESPACE
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type string$',
+        lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: int
@@ -218,8 +218,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: DEPLOYER_IMAGE
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        r'.*must be of type string$', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type string$',
+        lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: boolean
@@ -227,8 +227,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: APPLICATION_UID
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type boolean$', lambda:
-        config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type boolean$',
+        lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: string
@@ -236,8 +236,8 @@ class ConfigHelperTest(unittest.TestCase):
                   type: ISTIO_ENABLED
             """))
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema, r'.*must be of type boolean$', lambda:
-        config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, r'.*must be of type boolean$',
+        lambda: config_helper.Schema.load_yaml("""
             properties:
               u:
                 type: string
@@ -327,8 +327,8 @@ class ConfigHelperTest(unittest.TestCase):
   def test_image_default_missing_repo(self):
     self.assertRaisesRegexp(
         config_helper.InvalidSchema,
-        r'.*default image value must state registry', lambda: config_helper.
-        Schema.load_yaml("""
+        r'.*default image value must state registry',
+        lambda: config_helper.Schema.load_yaml("""
         properties:
           i:
             type: string
@@ -340,8 +340,8 @@ class ConfigHelperTest(unittest.TestCase):
   def test_image_default_missing_tag_or_digest(self):
     self.assertRaisesRegexp(
         config_helper.InvalidSchema,
-        r'.*default image value is missing a tag or digest', lambda:
-        config_helper.Schema.load_yaml("""
+        r'.*default image value is missing a tag or digest',
+        lambda: config_helper.Schema.load_yaml("""
         properties:
           i:
             type: string
@@ -502,8 +502,8 @@ class ConfigHelperTest(unittest.TestCase):
     self.assertEqual(False, schema.properties['pb'].str_to_type('False'))
     self.assertEqual(False, schema.properties['pb'].str_to_type('no'))
     self.assertEqual(False, schema.properties['pb'].str_to_type('No'))
-    self.assertRaises(config_helper.InvalidValue, lambda: schema.properties[
-        'pb'].str_to_type('bad'))
+    self.assertRaises(config_helper.InvalidValue,
+                      lambda: schema.properties['pb'].str_to_type('bad'))
 
   def test_invalid_default_type(self):
     self.assertRaises(
@@ -850,8 +850,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_missing_app_api_version(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        'applicationApiVersion', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, 'applicationApiVersion',
+        lambda: config_helper.Schema.load_yaml("""
             properties:
               simple:
                 type: string
@@ -859,8 +859,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_too_many_items(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        'form', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, 'form',
+        lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - widget: help
@@ -871,8 +871,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_missing_type(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        'form', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, 'form',
+        lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - description: My arbitrary <i>description</i>
@@ -880,8 +880,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_unrecognized_type(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        'form', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, 'form',
+        lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - widget: magical
@@ -890,8 +890,8 @@ class ConfigHelperTest(unittest.TestCase):
 
   def test_validate_bad_form_missing_description(self):
     self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        'form', lambda: config_helper.Schema.load_yaml("""
+        config_helper.InvalidSchema, 'form',
+        lambda: config_helper.Schema.load_yaml("""
             applicationApiVersion: v1beta1
             form:
             - widget: help

--- a/marketplace/deployer_util/expand_config_test.py
+++ b/marketplace/deployer_util/expand_config_test.py
@@ -44,8 +44,8 @@ class ExpandConfigTest(unittest.TestCase):
           p1:
             type: string
         """)
-    self.assertRaises(expand_config.InvalidProperty, lambda: expand_config.
-                      expand({'p1': 3}, schema))
+    self.assertRaises(expand_config.InvalidProperty,
+                      lambda: expand_config.expand({'p1': 3}, schema))
 
   def test_generate_properties_for_v1_image_split_by_colon(self):
     schema = config_helper.Schema.load_yaml("""

--- a/marketplace/deployer_util/expand_config_test.py
+++ b/marketplace/deployer_util/expand_config_test.py
@@ -44,8 +44,8 @@ class ExpandConfigTest(unittest.TestCase):
           p1:
             type: string
         """)
-    self.assertRaises(expand_config.InvalidProperty,
-                      lambda: expand_config.expand({'p1': 3}, schema))
+    self.assertRaises(expand_config.InvalidProperty, lambda: expand_config.
+                      expand({'p1': 3}, schema))
 
   def test_generate_properties_for_v1_image_split_by_colon(self):
     schema = config_helper.Schema.load_yaml("""
@@ -53,6 +53,7 @@ class ExpandConfigTest(unittest.TestCase):
         properties:
           i1:
             type: string
+            default: gcr.io/google/busybox:1.0
             x-google-marketplace:
               type: IMAGE
               image:
@@ -75,6 +76,7 @@ class ExpandConfigTest(unittest.TestCase):
         properties:
           i1:
             type: string
+            default: gcr.io/google/busybox:1.0
             x-google-marketplace:
               type: IMAGE
               image:

--- a/marketplace/deployer_util/print_config_test.py
+++ b/marketplace/deployer_util/print_config_test.py
@@ -119,5 +119,5 @@ class PrintConfigTest(unittest.TestCase):
               type: IMAGE
         """)
     self.assertRaises(
-        print_config.InvalidParameter, lambda: print_config.output_xtype(
-            values, schema, 'IMAGE', True))
+        print_config.InvalidParameter,
+        lambda: print_config.output_xtype(values, schema, 'IMAGE', True))

--- a/marketplace/deployer_util/print_config_test.py
+++ b/marketplace/deployer_util/print_config_test.py
@@ -109,13 +109,15 @@ class PrintConfigTest(unittest.TestCase):
         properties:
           image1:
             type: string
+            default: gcr.io/google/busybox:1.0
             x-google-marketplace:
               type: IMAGE
           image2:
             type: string
+            default: gcr.io/google/busybox:1.0
             x-google-marketplace:
               type: IMAGE
         """)
     self.assertRaises(
-        print_config.InvalidParameter,
-        lambda: print_config.output_xtype(values, schema, 'IMAGE', True))
+        print_config.InvalidParameter, lambda: print_config.output_xtype(
+            values, schema, 'IMAGE', True))


### PR DESCRIPTION
Although unused in the final deployment, these values are key for the publishing process since they indicate which staging GCR repo values to copy.

/gcbrun