### PR TITLE
Accept a canonical_image_pull_secret to create and apply to all KSAs during install

### DIFF
--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -21,6 +21,21 @@ from provision import limit_name
 import config_helper
 
 
+def mock_get_canonical_image_pull_secret_manifest(
+    canonical_image_pull_secret_name, target_namespace):
+  return {
+      'apiVersion': 'v1',
+      'kind': 'Secret',
+      'metadata': {
+          'name': canonical_image_pull_secret_name,
+          'namespace': target_namespace,
+      },
+      'data': {
+          'some-key': 'some-data',
+      },
+  }
+
+
 class ProvisionTest(unittest.TestCase):
 
   def test_dns1123_name(self):
@@ -80,3 +95,163 @@ class ProvisionTest(unittest.TestCase):
           'gcr.io/test/test@sha256:0123456789abcdef')
     with self.assertRaises(Exception):
       provision.deployer_image_to_repo_prefix('gcr.io/test/test:0.1.1')
+
+  def test_provision_service_account_image_pull_secrets(self):
+    schema = config_helper.Schema.load_yaml("""
+        properties:
+          sa:
+            type: string
+            x-google-marketplace:
+              type: SERVICE_ACCOUNT
+              serviceAccount:
+                roles:
+                - type: ClusterRole
+                  rulesType: PREDEFINED
+                  rulesFromRoleName: cluster-admin
+        """)
+    manifests = provision.provision_service_account(
+        schema, schema.properties['sa'], 'app-name-1', 'namespace-1',
+        'image-pull-secret-1', 'canonical-image-pull-secret-1',
+        mock_get_canonical_image_pull_secret_manifest)
+    self.assertIn(
+        {
+            'apiVersion':
+                'v1',
+            'kind':
+                'ServiceAccount',
+            'metadata': {
+                'name': 'app-name-1-sa',
+                'namespace': 'namespace-1',
+            },
+            'imagePullSecrets': [{
+                'name': 'image-pull-secret-1'
+            }, {
+                'name': 'canonical-image-pull-secret-1',
+            }],
+        }, manifests)
+    self.assertIn(
+        mock_get_canonical_image_pull_secret_manifest(
+            'canonical-image-pull-secret-1', 'namespace-1'), manifests)
+
+  def test_provision_deployer_image_pull_secrets(self):
+    schema = config_helper.Schema.load_yaml("""
+        x-google-marketplace:
+          # v2 required fields
+          schemaVersion: v2
+          applicationApiVersion: v1beta1
+          publishedVersion: 6.5.130
+          publishedVersionMetadata:
+            releaseNote: Bug fixes
+            releaseTypes:
+            - BUG_FIX
+          images:
+            main:
+              properties:
+                main.image:
+                  type: FULL
+          deployerServiceAccount:
+            roles:
+            - type: ClusterRole
+              rulesType: PREDEFINED
+              rulesFromRoleName: cluster-admin
+        properties:
+          simple:
+            type: string
+        """)
+    manifests = provision.provision_deployer(
+        schema,
+        'app-name-1',
+        'namespace-1',
+        'gcr.io/some-repo/some-app/deployer:1.0',
+        None,  # deployer_entrypoint
+        dict({'simple': 'some-value'}),
+        'image-pull-secret-1',
+        'canonical-image-pull-secret-1',
+        mock_get_canonical_image_pull_secret_manifest)
+    self.assertIn(
+        {
+            'apiVersion':
+                'v1',
+            'kind':
+                'ServiceAccount',
+            'metadata': {
+                'name': 'app-name-1-deployer-sa',
+                'namespace': 'namespace-1',
+                'labels': {
+                    'app.kubernetes.io/component':
+                        'deployer.marketplace.cloud.google.com',
+                    'marketplace.cloud.google.com/deployer':
+                        'Dependent',
+                },
+            },
+            'imagePullSecrets': [{
+                'name': 'image-pull-secret-1'
+            }, {
+                'name': 'canonical-image-pull-secret-1',
+            }],
+        }, manifests)
+    self.assertIn(
+        mock_get_canonical_image_pull_secret_manifest(
+            'canonical-image-pull-secret-1', 'namespace-1'), manifests)
+
+  def test_provision_kalm_image_pull_secrets(self):
+    schema = config_helper.Schema.load_yaml("""
+        x-google-marketplace:
+          schemaVersion: v2
+
+          applicationApiVersion: v1beta1
+
+          publishedVersion: 6.5.130
+          publishedVersionMetadata:
+            releaseNote: Bug fixes
+            releaseTypes:
+            - BUG_FIX
+            recommended: true
+
+          managedUpdates:
+            kalmSupported: true
+
+          images:
+            main:
+              properties:
+                main.image:
+                  type: FULL
+            db:
+              properties:
+                db.image.repo:
+                  type: REPO_WITH_REGISTRY
+                db.image.tag:
+                  type: TAG
+        properties:
+          simple:
+            type: string
+        """)
+    manifests = provision.provision_kalm(
+        schema, 'version-repo-1', 'app-name-1',
+        'namespace-1', 'gcr.io/some-repo/some-app/deployer:1.0',
+        dict({'simple': 'some-value'}), 'image-pull-secret-1',
+        'canonical-image-pull-secret-1',
+        mock_get_canonical_image_pull_secret_manifest)
+    self.assertIn(
+        {
+            'apiVersion':
+                'v1',
+            'kind':
+                'ServiceAccount',
+            'metadata': {
+                'name': 'app-name-1-deployer-sa',
+                'namespace': 'namespace-1',
+                'labels': {
+                    'app.kubernetes.io/component':
+                        'kalm.marketplace.cloud.google.com',
+                },
+            },
+            'imagePullSecrets': [{
+                'name': 'image-pull-secret-1'
+            }, {
+                'name': 'canonical-image-pull-secret-1',
+            }],
+        }, manifests)
+    self.assertIn(
+        mock_get_canonical_image_pull_secret_manifest(
+            'canonical-image-pull-secret-1', 'namespace-1'), manifests)

--- a/scripts/install
+++ b/scripts/install
@@ -39,6 +39,10 @@ case $i in
     image_pull_secret="${i#*=}"
     shift
     ;;
+  --canonical_image_pull_secret=*)
+    canonical_image_pull_secret="${i#*=}"
+    shift
+    ;;
   *)
     >&2 echo "Unrecognized flag: $i"
     exit 1
@@ -121,6 +125,7 @@ echo "${parameters}" \
     --deployer_entrypoint="${entrypoint}" \
     --version_repo="${version_repo}" \
     --image_pull_secret="${image_pull_secret}" \
+    --canonical_image_pull_secret="${canonical_image_pull_secret}" \
   | set_app_labels.py \
     --manifests=- \
     --dest=- \


### PR DESCRIPTION
Intended to replace the existing image_pull_secret (referencing an annotated image pull secret in the deployment namespace).

/gcbrun