### PR TITLE
Fix helm standard_v2 test and add to helm_tiller_onbuild make target

### DIFF
--- a/tests.Makefile
+++ b/tests.Makefile
@@ -62,8 +62,8 @@ TEST_ID := $(shell cat /dev/urandom | tr -dc 'a-z0-9' | head -c 8)
 .PHONY: tests/marketplace/deployer/helm_tiller_onbuild
 tests/marketplace/deployer/helm_tiller_onbuild: \
 		.tests/marketplace/deployer/helm_tiller_onbuild/helm-dependency-build \
-		.tests/marketplace/deployer/helm_tiller_onbuild/standard
-
+		.tests/marketplace/deployer/helm_tiller_onbuild/standard \
+		.tests/marketplace/deployer/helm_tiller_onbuild/standard_v2
 
 .tests/marketplace/deployer/envsubst:
 	mkdir -p "$@"

--- a/tests/marketplace/deployer_helm_tiller_base/onbuild/standard_v2/chart/minimal-helm-chart/templates/application.yaml
+++ b/tests/marketplace/deployer_helm_tiller_base/onbuild/standard_v2/chart/minimal-helm-chart/templates/application.yaml
@@ -9,7 +9,7 @@ spec:
   descriptor:
     description: |-
       A minimal example application.
-    version: 0.1.1
+    version: 0.0.1
   componentKinds:
   - group: batch/v1
     kind: Job

--- a/tests/marketplace/deployer_helm_tiller_base/onbuild/standard_v2/run_test
+++ b/tests/marketplace/deployer_helm_tiller_base/onbuild/standard_v2/run_test
@@ -7,7 +7,7 @@ test_directory=$(mktemp --dry-run)
 cp -r $(dirname "$0") "$test_directory"
 cd "$test_directory"
 
-image="$REGISTRY/$test_name:$MARKETPLACE_TOOLS_TAG-$TEST_ID"
+image="$REGISTRY/$test_name/deployer:$MARKETPLACE_TOOLS_TAG-$TEST_ID"
 
 docker build \
     --build-arg "MARKETPLACE_TOOLS_TAG=$MARKETPLACE_TOOLS_TAG" \


### PR DESCRIPTION
See that .tests/marketplace/deployer/helm_tiller_onbuild/standard_v2 is currently broken in [PR#391](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/pull/391).

/gcbrun