### PR TITLE
Fix name for provisioned ClusterRole{,Binding}s

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -438,7 +438,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
     })
   for i, rules in enumerate(
       deployer_service_account.custom_cluster_role_rules()):
-    role_name = '{}:{}:deployer-r{}'.format(namespace, app_name, i)
+    role_name = '{}:{}:deployer-cr{}'.format(namespace, app_name, i)
     roles_and_rolebindings.append({
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'ClusterRole',
@@ -452,7 +452,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'ClusterRoleBinding',
         'metadata': {
-            'name': '{}:{}:deployer-rb{}'.format(namespace, app_name, i),
+            'name': '{}:{}:deployer-crb{}'.format(namespace, app_name, i),
             'labels': labels,
         },
         'roleRef': {

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -46,6 +46,9 @@ class ProvisionTest(unittest.TestCase):
     self.assertEqual(text[:-5], expected)
     self.assertRegexpMatches(text[-5:], r'-[a-f0-9]{4}')
 
+  def assertListElementsEqual(self, list1, list2):
+    return self.assertEqual(list1.sort(), list2.sort())
+
   def test_deployer_image_inject(self):
     schema = config_helper.Schema.load_yaml('''
     properties:
@@ -162,7 +165,7 @@ class ProvisionTest(unittest.TestCase):
           simple:
             type: string
       """)
-    self.assertEquals(
+    self.assertListElementsEqual(
         [
             {
                 'apiVersion':
@@ -207,7 +210,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'ClusterRole',
                 'metadata': {
-                    'name': 'namespace-1:app-name-1:deployer-r0',
+                    'name': 'namespace-1:app-name-1:deployer-cr0',
                     'labels': ['label-1'],
                 },
                 'rules': [{
@@ -222,7 +225,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'ClusterRoleBinding',
                 'metadata': {
-                    'name': 'namespace-1:app-name-1:deployer-rb0',
+                    'name': 'namespace-1:app-name-1:deployer-crb0',
                     'labels': ['label-1'],
                 },
                 'roleRef': {

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -47,7 +47,7 @@ class ProvisionTest(unittest.TestCase):
     self.assertRegexpMatches(text[-5:], r'-[a-f0-9]{4}')
 
   def assertListElementsEqual(self, list1, list2):
-    return self.assertEqual(list1.sorted(), list2.sorted())
+    return self.assertEqual(sorted(list1), sorted(list2))
 
   def test_deployer_image_inject(self):
     schema = config_helper.Schema.load_yaml('''
@@ -231,7 +231,7 @@ class ProvisionTest(unittest.TestCase):
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
                     'kind': 'ClusterRole',
-                    'name': 'namespace-1:app-name-1:deployer-r0',
+                    'name': 'namespace-1:app-name-1:deployer-cr0',
                 },
                 'subjects': [{
                     'kind': 'ServiceAccount',

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -47,7 +47,7 @@ class ProvisionTest(unittest.TestCase):
     self.assertRegexpMatches(text[-5:], r'-[a-f0-9]{4}')
 
   def assertListElementsEqual(self, list1, list2):
-    return self.assertEqual(list1.sort(), list2.sort())
+    return self.assertEqual(list1.sorted(), list2.sorted())
 
   def test_deployer_image_inject(self):
     schema = config_helper.Schema.load_yaml('''
@@ -307,7 +307,7 @@ class ProvisionTest(unittest.TestCase):
           simple:
             type: string
       """)
-    self.assertEquals(
+    self.assertListElementsEqual(
         [
             # The default namespace rolebinding should also be created
             {


### PR DESCRIPTION
Differentiate names for ClusterRole{,Binding}s from Role{,Binding}s with a 'c'.

Also reduce test fragility by ignoring list order.

/gcbrun