### PR TITLE
Clean up provisioned custom deployer permissions after deployment

### DIFF
--- a/marketplace/deployer_util/clean_iam_resources.sh
+++ b/marketplace/deployer_util/clean_iam_resources.sh
@@ -27,11 +27,15 @@ kubectl delete --namespace="$NAMESPACE" \
   ServiceAccount,Role,RoleBinding \
   -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME" \
   --ignore-not-found
-# TODO(eshiroma): ensure that the cluster-scoped resources are deleted.
-# (Update wait_for_deletion to handle, and accept labels)
-# Note: the ClusterRole created for cleanup cannot be deleted here, as
-# its rules grant permission to clean up. It is deleted with the app.
 kubectl delete \
   ClusterRole,ClusterRoleBinding \
-  -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME" \
+  -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME",'marketplace.cloud.google.com/namespace'="$NAMESPACE" \
+  --ignore-not-found
+# Delete the ClusterRoleBinding that grants permission to clean up
+# cluster-scoped resources for the app. The ClusterRole itself cannot
+# be deleted, as its rules grant permission to clean up. Instead, the
+# ClusterRole is deleted with the app.
+kubectl delete \
+  ClusterRoleBinding \
+  -l 'app.kubernetes.io/component'='deployer-cleanup.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME",'marketplace.cloud.google.com/namespace'="$NAMESPACE" \
   --ignore-not-found

--- a/marketplace/deployer_util/clean_iam_resources.sh
+++ b/marketplace/deployer_util/clean_iam_resources.sh
@@ -23,9 +23,11 @@ set -eox pipefail
 # Note that only resources of a one-shot deployer have this label.
 # Resources of a KALM-managed deployer have
 # app.kubernetes.io/component=kalm.marketplace.cloud.google.com label.
-# TODO(eshiroma): Also clean up ClusterRoles and ClusterRoleBindings
-# once deployment grants the deployer permission.
 kubectl delete --namespace="$NAMESPACE" \
   ServiceAccount,Role,RoleBinding \
+  -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME" \
+  --ignore-not-found
+kubectl delete \
+  ClusterRole,ClusterRoleBinding \
   -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME" \
   --ignore-not-found

--- a/marketplace/deployer_util/clean_iam_resources.sh
+++ b/marketplace/deployer_util/clean_iam_resources.sh
@@ -32,9 +32,8 @@ kubectl delete \
   -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME",'marketplace.cloud.google.com/namespace'="$NAMESPACE" \
   --ignore-not-found
 # Delete the ClusterRoleBinding that grants permission to clean up
-# cluster-scoped resources for the app. The ClusterRole itself cannot
-# be deleted, as its rules grant permission to clean up. Instead, the
-# ClusterRole is deleted with the app.
+# cluster-scoped resources for the app. The ClusterRole is deleted with
+# the app since it cannot be deleted after the ClusterRoleBinding is removed.
 kubectl delete \
   ClusterRoleBinding \
   -l 'app.kubernetes.io/component'='deployer-cleanup.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME",'marketplace.cloud.google.com/namespace'="$NAMESPACE" \

--- a/marketplace/deployer_util/clean_iam_resources.sh
+++ b/marketplace/deployer_util/clean_iam_resources.sh
@@ -27,6 +27,10 @@ kubectl delete --namespace="$NAMESPACE" \
   ServiceAccount,Role,RoleBinding \
   -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME" \
   --ignore-not-found
+# TODO(eshiroma): ensure that the cluster-scoped resources are deleted.
+# (Update wait_for_deletion to handle, and accept labels)
+# Note: the ClusterRole created for cleanup cannot be deleted here, as
+# its rules grant permission to clean up. It is deleted with the app.
 kubectl delete \
   ClusterRole,ClusterRoleBinding \
   -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME" \

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -588,7 +588,7 @@ def make_cleanup_rolebindings(namespace, app_name, labels, subjects, role_names,
     # the empty resources names will grant control over all Roles.
     cleanup_clusterrole['rules'].append({
         'apiGroups': ['authorization.k8s.io'],
-        'resources': ['rolebindings'],
+        'resources': ['roles'],
         'resourceNames': role_names,
         'verbs': ['*'],
     })

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -438,7 +438,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
     })
   for i, rules in enumerate(
       deployer_service_account.custom_cluster_role_rules()):
-    role_name = '{}:{}:deployer-r{}'.format(namespace, app_name, i)
+    role_name = '{}:{}:deployer-cr{}'.format(namespace, app_name, i)
     roles_and_rolebindings.append({
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'ClusterRole',
@@ -452,7 +452,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'ClusterRoleBinding',
         'metadata': {
-            'name': '{}:{}:deployer-rb{}'.format(namespace, app_name, i),
+            'name': '{}:{}:deployer-crb{}'.format(namespace, app_name, i),
             'labels': labels,
         },
         'roleRef': {

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -509,13 +509,13 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'subjects': subjects,
     })
 
-  cleanup_rolebindings = make_cleanup_rolebindings(
-      namespace, app_name, labels, subjects,
-      get_name_list_by_kind('Role', roles_and_rolebindings),
-      get_name_list_by_kind('RoleBinding', roles_and_rolebindings),
-      get_name_list_by_kind('ClusterRole', roles_and_rolebindings),
-      get_name_list_by_kind('ClusterRoleBinding', roles_and_rolebindings))
-  roles_and_rolebindings.extend(cleanup_rolebindings)
+  roles_and_rolebindings.extend(
+      make_cleanup_rolebindings(
+          namespace, app_name, labels, subjects,
+          get_name_list_by_kind('Role', roles_and_rolebindings),
+          get_name_list_by_kind('RoleBinding', roles_and_rolebindings),
+          get_name_list_by_kind('ClusterRole', roles_and_rolebindings),
+          get_name_list_by_kind('ClusterRoleBinding', roles_and_rolebindings)))
 
   return roles_and_rolebindings
 

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -397,9 +397,10 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
   }
 
   roles_and_rolebindings = []
-  deployer_service_account = schema.x_google_marketplace.deployer_service_account
+  deployer_service_account = schema.is_v2(
+  ) and schema.x_google_marketplace.deployer_service_account
 
-  if not schema.is_v2() or not deployer_service_account:
+  if not deployer_service_account:
     roles_and_rolebindings.append(default_rolebinding)
     roles_and_rolebindings.extend(
         make_cleanup_rolebindings(

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -545,6 +545,9 @@ def make_cleanup_rolebindings(namespace, app_name, labels, subjects,
       'subjects': subjects,
   }
 
+  # This cannot be cleaned up with the rest of the ClusterRole{,Bindings},
+  # so omit the labels that are used to select the resources for deletion.
+  # It will be cleaned up during app deletion instead (by OwnerRef).
   cleanup_clusterrole = {
       'apiVersion':
           'rbac.authorization.k8s.io/v1',
@@ -552,7 +555,6 @@ def make_cleanup_rolebindings(namespace, app_name, labels, subjects,
           'ClusterRole',
       'metadata': {
           'name': cleanup_clusterrole_name,
-          'labels': labels,
       },
       'rules': [{
           'apiGroups': ['rbac.authorization.k8s.io'],

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -46,6 +46,9 @@ class ProvisionTest(unittest.TestCase):
     self.assertEqual(text[:-5], expected)
     self.assertRegexpMatches(text[-5:], r'-[a-f0-9]{4}')
 
+  def assertListElementsEqual(self, list1, list2):
+    return self.assertEqual(list1.sort(), list2.sort())
+
   def test_deployer_image_inject(self):
     schema = config_helper.Schema.load_yaml('''
     properties:
@@ -162,7 +165,7 @@ class ProvisionTest(unittest.TestCase):
           simple:
             type: string
       """)
-    self.assertEquals(
+    self.assertListElementsEqual(
         [
             {
                 'apiVersion':
@@ -207,7 +210,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'ClusterRole',
                 'metadata': {
-                    'name': 'namespace-1:app-name-1:deployer-r0',
+                    'name': 'namespace-1:app-name-1:deployer-cr0',
                     'labels': ['label-1'],
                 },
                 'rules': [{
@@ -222,7 +225,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'ClusterRoleBinding',
                 'metadata': {
-                    'name': 'namespace-1:app-name-1:deployer-rb0',
+                    'name': 'namespace-1:app-name-1:deployer-crb0',
                     'labels': ['label-1'],
                 },
                 'roleRef': {

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -85,7 +85,6 @@ class ProvisionTest(unittest.TestCase):
       provision.deployer_image_to_repo_prefix('gcr.io/test/test:0.1.1')
 
   def test_make_deployer_rolebindings_no_roles(self):
-    self.maxDiff = None
     schema = config_helper.Schema.load_yaml("""
         x-google-marketplace:
           # v2 required fields
@@ -368,11 +367,6 @@ class ProvisionTest(unittest.TestCase):
                     'verbs': ['get', 'watch', 'list'],
                 }, {
                     'apiGroups': ['authorization.k8s.io'],
-                    'resources': ['roles'],
-                    'resourceNames': ['app-name-1:deployer-r0'],
-                    'verbs': ['*'],
-                }, {
-                    'apiGroups': ['authorization.k8s.io'],
                     'resources': ['rolebindings'],
                     'resourceNames': [
                         'app-name-1:deployer-rb0', 'app-name-1:edit:deployer-rb'
@@ -394,6 +388,11 @@ class ProvisionTest(unittest.TestCase):
                         'namespace-1:app-name-1:deployer-crb0',
                         'namespace-1:app-name-1:cluster-admin:deployer-crb'
                     ],
+                    'verbs': ['*'],
+                }, {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['roles'],
+                    'resourceNames': ['app-name-1:deployer-r0'],
                     'verbs': ['*'],
                 }],
             },
@@ -526,7 +525,7 @@ class ProvisionTest(unittest.TestCase):
                         'resources': ['clusterrolebindings'],
                         'resourceNames': [
                             'namespace-1:app-name-1:deployer-cleanup-crb',
-                            'namespace-1:app-name-1:deployer-crb0'
+                            'namespace-1:app-name-1:cluster-admin:deployer-crb',
                         ],
                         'verbs': ['*'],
                     }

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -133,7 +133,6 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRole',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
-                    'labels': ['label-1'],
                 },
                 'rules': [
                     {
@@ -356,7 +355,6 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRole',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
-                    'labels': ['label-1'],
                 },
                 'rules': [{
                     'apiGroups': ['rbac.authorization.k8s.io'],
@@ -495,7 +493,6 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRole',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
-                    'labels': ['label-1'],
                 },
                 'rules': [
                     {

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -47,7 +47,7 @@ class ProvisionTest(unittest.TestCase):
     self.assertRegexpMatches(text[-5:], r'-[a-f0-9]{4}')
 
   def assertListElementsEqual(self, list1, list2):
-    return self.assertEqual(list1.sorted(), list2.sorted())
+    return self.assertEqual(sorted(list1), sorted(list2))
 
   def test_deployer_image_inject(self):
     schema = config_helper.Schema.load_yaml('''
@@ -231,7 +231,7 @@ class ProvisionTest(unittest.TestCase):
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
                     'kind': 'ClusterRole',
-                    'name': 'namespace-1:app-name-1:deployer-r0',
+                    'name': 'namespace-1:app-name-1:deployer-cr0',
                 },
                 'subjects': [{
                     'kind': 'ServiceAccount',

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -137,7 +137,7 @@ class ProvisionTest(unittest.TestCase):
                 },
                 'rules': [
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': [
                             'roles', 'rolebindings', 'clusterroles',
                             'clusterrolebindings'
@@ -146,20 +146,20 @@ class ProvisionTest(unittest.TestCase):
                     },
                     # There is no rule for roles since no roles were provisioned.
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': ['rolebindings'],
                         'resourceNames': ['app-name-1:deployer-rb'],
                         'verbs': ['*'],
                     },
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': ['clusterroles'],
                         'resourceNames':
                             ['namespace-1:app-name-1:deployer-cleanup-cr'],
                         'verbs': ['*'],
                     },
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': ['clusterrolebindings'],
                         'resourceNames':
                             ['namespace-1:app-name-1:deployer-cleanup-crb'],
@@ -359,38 +359,38 @@ class ProvisionTest(unittest.TestCase):
                     'labels': ['label-1'],
                 },
                 'rules': [{
-                    'apiGroups': ['authorization.k8s.io'],
+                    'apiGroups': ['rbac.authorization.k8s.io'],
                     'resources': [
                         'roles', 'rolebindings', 'clusterroles',
                         'clusterrolebindings'
                     ],
                     'verbs': ['get', 'watch', 'list'],
                 }, {
-                    'apiGroups': ['authorization.k8s.io'],
+                    'apiGroups': ['rbac.authorization.k8s.io'],
                     'resources': ['rolebindings'],
                     'resourceNames': [
                         'app-name-1:deployer-rb0', 'app-name-1:edit:deployer-rb'
                     ],
                     'verbs': ['*'],
                 }, {
-                    'apiGroups': ['authorization.k8s.io'],
+                    'apiGroups': ['rbac.authorization.k8s.io'],
                     'resources': ['clusterroles'],
                     'resourceNames': [
+                        'namespace-1:app-name-1:deployer-cr0',
                         'namespace-1:app-name-1:deployer-cleanup-cr',
-                        'namespace-1:app-name-1:deployer-cr0'
                     ],
                     'verbs': ['*'],
                 }, {
-                    'apiGroups': ['authorization.k8s.io'],
+                    'apiGroups': ['rbac.authorization.k8s.io'],
                     'resources': ['clusterrolebindings'],
                     'resourceNames': [
-                        'namespace-1:app-name-1:deployer-cleanup-crb',
                         'namespace-1:app-name-1:deployer-crb0',
-                        'namespace-1:app-name-1:cluster-admin:deployer-crb'
+                        'namespace-1:app-name-1:cluster-admin:deployer-crb',
+                        'namespace-1:app-name-1:deployer-cleanup-crb',
                     ],
                     'verbs': ['*'],
                 }, {
-                    'apiGroups': ['authorization.k8s.io'],
+                    'apiGroups': ['rbac.authorization.k8s.io'],
                     'resources': ['roles'],
                     'resourceNames': ['app-name-1:deployer-r0'],
                     'verbs': ['*'],
@@ -499,7 +499,7 @@ class ProvisionTest(unittest.TestCase):
                 },
                 'rules': [
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': [
                             'roles', 'rolebindings', 'clusterroles',
                             'clusterrolebindings'
@@ -508,24 +508,24 @@ class ProvisionTest(unittest.TestCase):
                     },
                     # There is no rule for roles since no roles were provisioned.
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': ['rolebindings'],
                         'resourceNames': ['app-name-1:deployer-rb'],
                         'verbs': ['*'],
                     },
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': ['clusterroles'],
                         'resourceNames':
                             ['namespace-1:app-name-1:deployer-cleanup-cr'],
                         'verbs': ['*'],
                     },
                     {
-                        'apiGroups': ['authorization.k8s.io'],
+                        'apiGroups': ['rbac.authorization.k8s.io'],
                         'resources': ['clusterrolebindings'],
                         'resourceNames': [
-                            'namespace-1:app-name-1:deployer-cleanup-crb',
                             'namespace-1:app-name-1:cluster-admin:deployer-crb',
+                            'namespace-1:app-name-1:deployer-cleanup-crb',
                         ],
                         'verbs': ['*'],
                     }

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -47,7 +47,7 @@ class ProvisionTest(unittest.TestCase):
     self.assertRegexpMatches(text[-5:], r'-[a-f0-9]{4}')
 
   def assertListElementsEqual(self, list1, list2):
-    return self.assertEqual(list1.sort(), list2.sort())
+    return self.assertEqual(list1.sorted(), list2.sorted())
 
   def test_deployer_image_inject(self):
     schema = config_helper.Schema.load_yaml('''
@@ -307,7 +307,7 @@ class ProvisionTest(unittest.TestCase):
           simple:
             type: string
       """)
-    self.assertEquals(
+    self.assertListElementsEqual(
         [
             # The default namespace rolebinding should also be created
             {

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import unittest
-import logging
 
 import provision
 from provision import dns1123_name

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -165,7 +165,7 @@ class ProvisionTest(unittest.TestCase):
           simple:
             type: string
       """)
-    self.assertListElementsEqual(
+    self.assertEqual(
         [
             {
                 'apiVersion':
@@ -280,7 +280,75 @@ class ProvisionTest(unittest.TestCase):
                     'name': 'app-name-deployer-sa',
                     'namespace': 'namespace-1',
                 }],
-            }
+            },
+            # Include permission to read all IAM resources, and to modify the provisioned resources
+            {
+                'apiVersion':
+                    'rbac.authorization.k8s.io/v1',
+                'kind':
+                    'ClusterRole',
+                'metadata': {
+                    'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
+                    'labels': ['label-1'],
+                },
+                'rules': [{
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': [
+                        'roles', 'rolebindings', 'clusterroles',
+                        'clusterrolebindings'
+                    ],
+                    'verbs': ['get', 'watch', 'list'],
+                }, {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['roles'],
+                    'resourceNames': ['app-name-1:deployer-r0'],
+                    'verbs': ['*'],
+                }, {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['rolebindings'],
+                    'resourceNames': [
+                        'app-name-1:deployer-rb0', 'app-name-1:edit:deployer-rb'
+                    ],
+                    'verbs': ['*'],
+                }, {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['clusterroles'],
+                    'resourceNames': [
+                        'namespace-1:app-name-1:deployer-cleanup-cr',
+                        'namespace-1:app-name-1:deployer-cr0'
+                    ],
+                    'verbs': ['*'],
+                }, {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['clusterrolebindings'],
+                    'resourceNames': [
+                        'namespace-1:app-name-1:deployer-cleanup-crb',
+                        'namespace-1:app-name-1:deployer-crb0',
+                        'namespace-1:app-name-1:cluster-admin:deployer-crb'
+                    ],
+                    'verbs': ['*'],
+                }],
+            },
+            {
+                'apiVersion':
+                    'rbac.authorization.k8s.io/v1',
+                'kind':
+                    'ClusterRoleBinding',
+                'metadata': {
+                    'name': 'namespace-1:app-name-1:deployer-cleanup-crb',
+                    'labels': ['label-1'],
+                },
+                'roleRef': {
+                    'apiGroup': 'rbac.authorization.k8s.io',
+                    'kind': 'ClusterRole',
+                    'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
+                },
+                'subjects': [{
+                    'kind': 'ServiceAccount',
+                    'name': 'app-name-deployer-sa',
+                    'namespace': 'namespace-1',
+                }],
+            },
         ],
         provision.make_deployer_rolebindings(schema, 'namespace-1',
                                              'app-name-1', ['label-1'],
@@ -351,7 +419,57 @@ class ProvisionTest(unittest.TestCase):
                     'name': 'app-name-deployer-sa',
                     'namespace': 'namespace-1',
                 }],
-            }
+            },
+            # Include permission to read all IAM resources, and to modify the provisioned resources
+            {
+                'apiVersion': 'rbac.authorization.k8s.io/v1',
+                'kind': 'ClusterRole',
+                'metadata': {
+                    'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
+                    'labels': ['label-1'],
+                },
+                'rules': [
+                {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['roles', 'rolebindings', 'clusterroles', 'clusterrolebindings'],
+                    'verbs': ['get', 'watch', 'list'],
+                },
+                # There is no rule for roles since no roles were provisioned.
+                {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['rolebindings'],
+                    'resourceNames': ['app-name-1:deployer-rb'],
+                    'verbs': ['*'],
+                }, {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['clusterroles'],
+                    'resourceNames': ['namespace-1:app-name-1:deployer-cleanup-cr'],
+                    'verbs': ['*'],
+                }, {
+                    'apiGroups': ['authorization.k8s.io'],
+                    'resources': ['clusterrolebindings'],
+                    'resourceNames': ['namespace-1:app-name-1:deployer-cleanup-crb', 'namespace-1:app-name-1:deployer-crb0'],
+                    'verbs': ['*'],
+                }],
+            },
+            {
+                'apiVersion': 'rbac.authorization.k8s.io/v1',
+                'kind': 'ClusterRoleBinding',
+                'metadata': {
+                    'name': 'namespace-1:app-name-1:deployer-cleanup-crb',
+                    'labels': ['label-1'],
+                },
+                'roleRef': {
+                    'apiGroup': 'rbac.authorization.k8s.io',
+                    'kind': 'ClusterRole',
+                    'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
+                },
+                'subjects': [{
+                    'kind': 'ServiceAccount',
+                    'name': 'app-name-deployer-sa',
+                    'namespace': 'namespace-1',
+                }], 
+            },
         ],
         provision.make_deployer_rolebindings(schema, 'namespace-1',
                                              'app-name-1', ['label-1'],

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -111,7 +111,9 @@ class ProvisionTest(unittest.TestCase):
                 'metadata': {
                     'name': 'app-name-1:deployer-rb',
                     'namespace': 'namespace-1',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'label-key': 'label-value'
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -133,6 +135,12 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRole',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
+                    'labels': {
+                        'app.kubernetes.io/component':
+                            'deployer-cleanup.marketplace.cloud.google.com',
+                        'marketplace.cloud.google.com/deployer':
+                            'Dependent',
+                    },
                 },
                 'rules': [
                     {
@@ -173,7 +181,12 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRoleBinding',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-crb',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'app.kubernetes.io/component':
+                            'deployer-cleanup.marketplace.cloud.google.com',
+                        'marketplace.cloud.google.com/deployer':
+                            'Dependent',
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -187,13 +200,10 @@ class ProvisionTest(unittest.TestCase):
                 }],
             },
         ],
-        provision.make_deployer_rolebindings(schema, 'namespace-1',
-                                             'app-name-1', ['label-1'],
-                                             'app-name-deployer-sa'))
-    logging.warning('ACTUAL:\n{}'.format(
-        provision.make_deployer_rolebindings(schema, 'namespace-1',
-                                             'app-name-1', ['label-1'],
-                                             'app-name-deployer-sa')))
+        provision.make_deployer_rolebindings(
+            schema, 'namespace-1', 'app-name-1', {'label-key': 'label-value'},
+            {'cluster-scope-label-key': 'cluster-scope-label-value'},
+            'app-name-deployer-sa'))
 
   def test_make_deployer_rolebindings_all_roles(self):
     schema = config_helper.Schema.load_yaml("""
@@ -241,7 +251,9 @@ class ProvisionTest(unittest.TestCase):
                 'metadata': {
                     'name': 'app-name-1:deployer-r0',
                     'namespace': 'namespace-1',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'label-key': 'label-value'
+                    },
                 },
                 'rules': [{
                     'apiGroups': ['apps/v1'],
@@ -257,7 +269,9 @@ class ProvisionTest(unittest.TestCase):
                 'metadata': {
                     'name': 'app-name-1:deployer-rb0',
                     'namespace': 'namespace-1',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'label-key': 'label-value'
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -277,7 +291,9 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRole',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cr0',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'cluster-scope-label-key': 'cluster-scope-label-value'
+                    },
                 },
                 'rules': [{
                     'apiGroups': ['v1'],
@@ -292,7 +308,9 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRoleBinding',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-crb0',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'cluster-scope-label-key': 'cluster-scope-label-value'
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -313,7 +331,9 @@ class ProvisionTest(unittest.TestCase):
                 'metadata': {
                     'name': 'app-name-1:edit:deployer-rb',
                     'namespace': 'namespace-1',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'label-key': 'label-value'
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -334,7 +354,9 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRoleBinding',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:cluster-admin:deployer-crb',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'cluster-scope-label-key': 'cluster-scope-label-value'
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -355,6 +377,12 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRole',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
+                    'labels': {
+                        'app.kubernetes.io/component':
+                            'deployer-cleanup.marketplace.cloud.google.com',
+                        'marketplace.cloud.google.com/deployer':
+                            'Dependent',
+                    },
                 },
                 'rules': [{
                     'apiGroups': ['rbac.authorization.k8s.io'],
@@ -401,7 +429,12 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRoleBinding',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-crb',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'app.kubernetes.io/component':
+                            'deployer-cleanup.marketplace.cloud.google.com',
+                        'marketplace.cloud.google.com/deployer':
+                            'Dependent',
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -415,9 +448,10 @@ class ProvisionTest(unittest.TestCase):
                 }],
             },
         ],
-        provision.make_deployer_rolebindings(schema, 'namespace-1',
-                                             'app-name-1', ['label-1'],
-                                             'app-name-deployer-sa'))
+        provision.make_deployer_rolebindings(
+            schema, 'namespace-1', 'app-name-1', {'label-key': 'label-value'},
+            {'cluster-scope-label-key': 'cluster-scope-label-value'},
+            'app-name-deployer-sa'))
 
   def test_make_deployer_rolebindings_clusterrole_only(self):
     schema = config_helper.Schema.load_yaml("""
@@ -451,7 +485,9 @@ class ProvisionTest(unittest.TestCase):
                 'metadata': {
                     'name': 'app-name-1:deployer-rb',
                     'namespace': 'namespace-1',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'label-key': 'label-value'
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -472,7 +508,9 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRoleBinding',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:cluster-admin:deployer-crb',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'cluster-scope-label-key': 'cluster-scope-label-value'
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -493,6 +531,12 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRole',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-cr',
+                    'labels': {
+                        'app.kubernetes.io/component':
+                            'deployer-cleanup.marketplace.cloud.google.com',
+                        'marketplace.cloud.google.com/deployer':
+                            'Dependent',
+                    },
                 },
                 'rules': [
                     {
@@ -535,7 +579,12 @@ class ProvisionTest(unittest.TestCase):
                     'ClusterRoleBinding',
                 'metadata': {
                     'name': 'namespace-1:app-name-1:deployer-cleanup-crb',
-                    'labels': ['label-1'],
+                    'labels': {
+                        'app.kubernetes.io/component':
+                            'deployer-cleanup.marketplace.cloud.google.com',
+                        'marketplace.cloud.google.com/deployer':
+                            'Dependent',
+                    },
                 },
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
@@ -549,6 +598,7 @@ class ProvisionTest(unittest.TestCase):
                 }],
             },
         ],
-        provision.make_deployer_rolebindings(schema, 'namespace-1',
-                                             'app-name-1', ['label-1'],
-                                             'app-name-deployer-sa'))
+        provision.make_deployer_rolebindings(
+            schema, 'namespace-1', 'app-name-1', {'label-key': 'label-value'},
+            {'cluster-scope-label-key': 'cluster-scope-label-value'},
+            'app-name-deployer-sa'))

--- a/scripts/verify
+++ b/scripts/verify
@@ -280,13 +280,18 @@ echo "INFO Wait for service accounts to be deleted."
   --kind=serviceaccounts,roles,rolebindings \
   --timeout="$deletion_timeout" \
   || clean_and_exit "ERROR Some service accounts or roles were not deleted"
-selector="app.kubernetes.io/component=deployer.marketplace.cloud.google.com,app.kubernetes.io/name=$NAME"
 /scripts/wait_for_deletion.sh \
   --namespace="" \
   --kind=clusterroles,clusterrolebindings \
   --timeout="$deletion_timeout" \
-  --selector="$selector" \
+  --selector="app.kubernetes.io/component=deployer.marketplace.cloud.google.com,app.kubernetes.io/name=$NAME" \
   || clean_and_exit "ERROR Some roles were not deleted"
+/scripts/wait_for_deletion.sh \
+  --namespace="" \
+  --kind=clusterrolebindings \
+  --timeout="$deletion_timeout" \
+  --selector="app.kubernetes.io/component=deployer-cleanup.marketplace.cloud.google.com,app.kubernetes.io/name=$NAME" \
+  || clean_and_exit "ERROR ClusterRoleBinding for resource cleanup was not deleted"
 trap - EXIT
 
 clean_resources

--- a/scripts/verify
+++ b/scripts/verify
@@ -280,7 +280,13 @@ echo "INFO Wait for service accounts to be deleted."
   --kind=serviceaccounts,roles,rolebindings \
   --timeout="$deletion_timeout" \
   || clean_and_exit "ERROR Some service accounts or roles were not deleted"
-
+selector="app.kubernetes.io/component=deployer.marketplace.cloud.google.com,app.kubernetes.io/name=$NAME"
+/scripts/wait_for_deletion.sh \
+  --namespace="" \
+  --kind=clusterroles,clusterrolebindings \
+  --timeout="$deletion_timeout" \
+  --selector="$selector" \
+  || clean_and_exit "ERROR Some roles were not deleted"
 trap - EXIT
 
 clean_resources

--- a/scripts/wait_for_deletion.sh
+++ b/scripts/wait_for_deletion.sh
@@ -31,6 +31,10 @@ case $i in
     timeout="${i#*=}"
     shift
     ;;
+  --selector=*)
+    selector="${i#*=}"
+    shift
+    ;;
   *)
     echo "Unrecognized flag: $i"
     exit 1
@@ -43,9 +47,11 @@ poll_interval=4
 
 while true; do
   # Everything under the namespace needs to be removed after app/uninstall
+  # Can also be called with an empty namespace for cluster-scoped resources.
   echo "INFO Checking if $kind were deleted"
   resources=$(kubectl get $kind \
     --namespace="$namespace" \
+    --selector "$selector" \
     -o=json \
     | jq -r '.items[] | "\(.kind)/\(.metadata.name)"')
 


### PR DESCRIPTION
Grants the deployer permission to list IAM resources and to delete the ones provisioned for deployment (by name). Deletes the provisioned resources after deployment, and then the ClusterRoleBinding that grants permission to perform these deletions.

Note: Should not be released until the UI has been updated (and released) to grant the new cleanup permissions and set the corresponding labels.

/gcbrun