### PR TITLE
Only apply the App OwnerRef to namespaced resources

### DIFF
--- a/marketplace/deployer_util/resources.py
+++ b/marketplace/deployer_util/resources.py
@@ -27,12 +27,15 @@ def set_resource_ownership(app_uid, app_name, app_api_version, resource):
       owner_reference = existing_owner_reference
       break
 
-  if not owner_reference:
+  # Only set an OwnerRef on namespaced resources.
+  if (not owner_reference and 'namespace' in resource['metadata'] and
+      resource['metadata']['namespace']):
     owner_reference = {}
     resource['metadata']['ownerReferences'].append(owner_reference)
 
-  owner_reference['apiVersion'] = app_api_version
-  owner_reference['kind'] = "Application"
-  owner_reference['blockOwnerDeletion'] = True
-  owner_reference['name'] = app_name
-  owner_reference['uid'] = app_uid
+  if owner_reference != None:
+    owner_reference['apiVersion'] = app_api_version
+    owner_reference['kind'] = "Application"
+    owner_reference['blockOwnerDeletion'] = True
+    owner_reference['name'] = app_name
+    owner_reference['uid'] = app_uid

--- a/marketplace/deployer_util/resources.py
+++ b/marketplace/deployer_util/resources.py
@@ -27,7 +27,8 @@ def set_resource_ownership(app_uid, app_name, app_api_version, resource):
       owner_reference = existing_owner_reference
       break
 
-  # Only set an OwnerRef on namespaced resources.
+  # Only set an OwnerRef on namespaced resources to comply with k8s spec.
+  # https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents
   if (not owner_reference and 'namespace' in resource['metadata'] and
       resource['metadata']['namespace']):
     owner_reference = {}

--- a/marketplace/deployer_util/resources.py
+++ b/marketplace/deployer_util/resources.py
@@ -27,16 +27,12 @@ def set_resource_ownership(app_uid, app_name, app_api_version, resource):
       owner_reference = existing_owner_reference
       break
 
-  # Only set an OwnerRef on namespaced resources to comply with k8s spec.
-  # https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents
-  if (not owner_reference and 'namespace' in resource['metadata'] and
-      resource['metadata']['namespace']):
+  if not owner_reference:
     owner_reference = {}
     resource['metadata']['ownerReferences'].append(owner_reference)
 
-  if owner_reference != None:
-    owner_reference['apiVersion'] = app_api_version
-    owner_reference['kind'] = "Application"
-    owner_reference['blockOwnerDeletion'] = True
-    owner_reference['name'] = app_name
-    owner_reference['uid'] = app_uid
+  owner_reference['apiVersion'] = app_api_version
+  owner_reference['kind'] = "Application"
+  owner_reference['blockOwnerDeletion'] = True
+  owner_reference['name'] = app_name
+  owner_reference['uid'] = app_uid

--- a/marketplace/deployer_util/resources_test.py
+++ b/marketplace/deployer_util/resources_test.py
@@ -1,0 +1,83 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from resources import set_resource_ownership
+
+APP_API_VERSION = 'v1beta1'
+APP_NAME = 'wordpress-1'
+APP_UID = '00000000-1111-2222-3333-444444444444'
+OTHER_UID = '99999999-9999-9999-9999-999999999999'
+APP_OWNER_REF = {
+    'apiVersion': APP_API_VERSION,
+    'kind': 'Application',
+    'blockOwnerDeletion': True,
+    'name': APP_NAME,
+    'uid': APP_UID,
+}
+
+
+class ResourcesTest(unittest.TestCase):
+
+  def assertListElementsEqual(self, list1, list2):
+    return self.assertEqual(sorted(list1), sorted(list2))
+
+
+# def set_resource_ownership(app_uid, app_name, app_api_version, resource):
+
+  def test_resource_existing_app_ownerref_matching_uid_updates_existing(self):
+    resource = {
+        'metadata': {
+            'namespace': 'default',
+            'ownerReferences': [{
+                'uid': APP_UID
+            }]
+        }
+    }
+
+    set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
+
+    self.assertListElementsEqual(resource['metadata']['ownerReferences'],
+                                 [APP_OWNER_REF])
+
+  def test_resource_existing_app_ownerref_different_uid_adds_ownerref(self):
+    resource = {
+        'metadata': {
+            'namespace': 'default',
+            'ownerReferences': [{
+                'uid': OTHER_UID
+            }]
+        }
+    }
+
+    set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
+
+    self.assertListElementsEqual(resource['metadata']['ownerReferences'], [{
+        'uid': OTHER_UID
+    }, APP_OWNER_REF])
+
+  def test_resource_no_ownerrefs_adds_ownerref(self):
+    resource = {'metadata': {'namespace': 'default', 'ownerReferences': []}}
+
+    set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
+
+    self.assertListElementsEqual(resource['metadata']['ownerReferences'],
+                                 [APP_OWNER_REF])
+
+  def test_cluster_scoped_resource_no_ownerrefs_noop(self):
+    resource = {'metadata': {'ownerReferences': []}}
+
+    set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
+
+    self.assertListElementsEqual(resource['metadata']['ownerReferences'], [])

--- a/marketplace/deployer_util/resources_test.py
+++ b/marketplace/deployer_util/resources_test.py
@@ -74,10 +74,3 @@ class ResourcesTest(unittest.TestCase):
 
     self.assertListElementsEqual(resource['metadata']['ownerReferences'],
                                  [APP_OWNER_REF])
-
-  def test_cluster_scoped_resource_no_ownerrefs_noop(self):
-    resource = {'metadata': {'ownerReferences': []}}
-
-    set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
-
-    self.assertListElementsEqual(resource['metadata']['ownerReferences'], [])

--- a/marketplace/deployer_util/resources_test.py
+++ b/marketplace/deployer_util/resources_test.py
@@ -37,14 +37,7 @@ class ResourcesTest(unittest.TestCase):
 # def set_resource_ownership(app_uid, app_name, app_api_version, resource):
 
   def test_resource_existing_app_ownerref_matching_uid_updates_existing(self):
-    resource = {
-        'metadata': {
-            'namespace': 'default',
-            'ownerReferences': [{
-                'uid': APP_UID
-            }]
-        }
-    }
+    resource = {'metadata': {'ownerReferences': [{'uid': APP_UID}]}}
 
     set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
 
@@ -52,14 +45,7 @@ class ResourcesTest(unittest.TestCase):
                                  [APP_OWNER_REF])
 
   def test_resource_existing_app_ownerref_different_uid_adds_ownerref(self):
-    resource = {
-        'metadata': {
-            'namespace': 'default',
-            'ownerReferences': [{
-                'uid': OTHER_UID
-            }]
-        }
-    }
+    resource = {'metadata': {'ownerReferences': [{'uid': OTHER_UID}]}}
 
     set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
 
@@ -68,7 +54,7 @@ class ResourcesTest(unittest.TestCase):
     }, APP_OWNER_REF])
 
   def test_resource_no_ownerrefs_adds_ownerref(self):
-    resource = {'metadata': {'namespace': 'default', 'ownerReferences': []}}
+    resource = {'metadata': {'ownerReferences': []}}
 
     set_resource_ownership(APP_UID, APP_NAME, APP_API_VERSION, resource)
 

--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -106,8 +106,8 @@ def main():
 
     kinds = map(lambda x: x["kind"], apps[0]["spec"].get("componentKinds", []))
 
-    excluded_kinds = ["PersistentVolumeClaim",
-                      "Application"].extend(_CLUSTER_SCOPED_KINDS)
+    excluded_kinds = ["PersistentVolumeClaim", "Application"]
+    excluded_kinds.extend(_CLUSTER_SCOPED_KINDS)
     included_kinds = [kind for kind in kinds if kind not in excluded_kinds]
   else:
     included_kinds = None

--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -29,8 +29,10 @@ _PROG_HELP = """
 Scans the manifest folder kubernetes resources and set the Application to own
 the ones defined in its list of components kinds.
 """
-# All Kinds from `kubectl api-resources --namespaced=false`
+# From `kubectl api-resources --namespaced=false` with kubectl client and
+# server version of 1.13
 _CLUSTER_SCOPED_KINDS = [
+    "ComponentStatus",
     "Namespace",
     "Node",
     "PersistentVolume",
@@ -38,22 +40,17 @@ _CLUSTER_SCOPED_KINDS = [
     "ValidatingWebhookConfiguration",
     "CustomResourceDefinition",
     "APIService",
-    "AuditSink",
     "TokenReview",
     "SelfSubjectAccessReview",
     "SelfSubjectRulesReview",
     "SubjectAccessReview",
     "CertificateSigningRequest",
     "PodSecurityPolicy",
-    "StorageState",
-    "StorageVersionMigration",
-    "RuntimeClass",
+    "NodeMetrics",
     "PodSecurityPolicy",
     "ClusterRoleBinding",
     "ClusterRole",
     "PriorityClass",
-    "CSIDriver",
-    "CSINode",
     "StorageClass",
     "VolumeAttachment",
 ]

--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -29,6 +29,34 @@ _PROG_HELP = """
 Scans the manifest folder kubernetes resources and set the Application to own
 the ones defined in its list of components kinds.
 """
+# All Kinds from `kubectl api-resources --namespaced=false`
+_CLUSTER_SCOPED_KINDS = [
+    "Namespace",
+    "Node",
+    "PersistentVolume",
+    "MutatingWebhookConfiguration",
+    "ValidatingWebhookConfiguration",
+    "CustomResourceDefinition",
+    "APIService",
+    "AuditSink",
+    "TokenReview",
+    "SelfSubjectAccessReview",
+    "SelfSubjectRulesReview",
+    "SubjectAccessReview",
+    "CertificateSigningRequest",
+    "PodSecurityPolicy",
+    "StorageState",
+    "StorageVersionMigration",
+    "RuntimeClass",
+    "PodSecurityPolicy",
+    "ClusterRoleBinding",
+    "ClusterRole",
+    "PriorityClass",
+    "CSIDriver",
+    "CSINode",
+    "StorageClass",
+    "VolumeAttachment",
+]
 
 
 def main():
@@ -81,7 +109,8 @@ def main():
 
     kinds = map(lambda x: x["kind"], apps[0]["spec"].get("componentKinds", []))
 
-    excluded_kinds = ["PersistentVolumeClaim", "Application"]
+    excluded_kinds = ["PersistentVolumeClaim",
+                      "Application"].extend(_CLUSTER_SCOPED_KINDS)
     included_kinds = [kind for kind in kinds if kind not in excluded_kinds]
   else:
     included_kinds = None


### PR DESCRIPTION
Prevent applying OwnerRefs that do not comply with the [Kubernetes spec](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents) (which forbids namespaced resources owning cluster-scoped resources).

/gcbrun