### PR TITLE
Use REGISTRY var in marketplace/build Make command

### DIFF
--- a/marketplace.Makefile
+++ b/marketplace.Makefile
@@ -20,13 +20,14 @@ marketplace/build: .build/marketplace/dev \
 
 .build/marketplace/dev: \
 		.build/var/MARKETPLACE_TOOLS_TAG \
+		.build/var/REGISTRY \
 		$(shell find marketplace/deployer_util -type f) \
 		$(shell find marketplace/dev -type f) \
 		$(shell find scripts -type f) \
 		| .build/marketplace
 	$(call print_target)
 	docker build \
-	    --tag "gcr.io/cloud-marketplace-tools/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
+	    --tag "$(REGISTRY)/k8s/dev:$(MARKETPLACE_TOOLS_TAG)" \
 	    -f marketplace/dev/Dockerfile \
 	    .
 	@touch "$@"
@@ -38,12 +39,13 @@ marketplace/build: .build/marketplace/dev \
 
 .build/marketplace/deployer/envsubst: \
 		.build/var/MARKETPLACE_TOOLS_TAG \
+		.build/var/REGISTRY \
 		$(shell find marketplace/deployer_util -type f) \
 		$(shell find marketplace/deployer_envsubst_base -type f) \
 		| .build/marketplace/deployer
 	$(call print_target)
 	docker build \
-	    --tag "gcr.io/cloud-marketplace-tools/k8s/deployer_envsubst:$(MARKETPLACE_TOOLS_TAG)" \
+	    --tag "$(REGISTRY)/k8s/deployer_envsubst:$(MARKETPLACE_TOOLS_TAG)" \
 	    -f marketplace/deployer_envsubst_base/Dockerfile \
 	    .
 	@touch "$@"
@@ -51,12 +53,13 @@ marketplace/build: .build/marketplace/dev \
 
 .build/marketplace/deployer/helm: \
 		.build/var/MARKETPLACE_TOOLS_TAG \
+		.build/var/REGISTRY \
 		$(shell find marketplace/deployer_util -type f) \
 		$(shell find marketplace/deployer_helm_base -type f) \
 		| .build/marketplace/deployer
 	$(call print_target)
 	docker build \
-	    --tag "gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$(MARKETPLACE_TOOLS_TAG)" \
+	    --tag "$(REGISTRY)/k8s/deployer_helm:$(MARKETPLACE_TOOLS_TAG)" \
 	    -f marketplace/deployer_helm_base/Dockerfile \
 	    .
 	@touch "$@"
@@ -64,12 +67,13 @@ marketplace/build: .build/marketplace/dev \
 
 .build/marketplace/deployer/helm_tiller: \
 		.build/var/MARKETPLACE_TOOLS_TAG \
+		.build/var/REGISTRY \
 		$(shell find marketplace/deployer_util -type f) \
 		$(shell find marketplace/deployer_helm_tiller_base -type f) \
 		| .build/marketplace/deployer
 	$(call print_target)
 	docker build \
-	    --tag "gcr.io/cloud-marketplace-tools/k8s/deployer_helm_tiller:$(MARKETPLACE_TOOLS_TAG)" \
+	    --tag "$(REGISTRY)/k8s/deployer_helm_tiller:$(MARKETPLACE_TOOLS_TAG)" \
 	    -f marketplace/deployer_helm_tiller_base/Dockerfile \
 	    .
 	@touch "$@"
@@ -78,13 +82,14 @@ marketplace/build: .build/marketplace/dev \
 .build/marketplace/deployer/helm_tiller_onbuild: \
 		.build/marketplace/deployer/helm_tiller \
 		.build/var/MARKETPLACE_TOOLS_TAG \
+		.build/var/REGISTRY \
 		$(shell find marketplace/deployer_util -type f) \
 		$(shell find marketplace/deployer_helm_tiller_base/onbuild -type f) \
 		| .build/marketplace/deployer
 	$(call print_target)
 	docker build \
-	    --build-arg FROM="gcr.io/cloud-marketplace-tools/k8s/deployer_helm_tiller:$(MARKETPLACE_TOOLS_TAG)" \
-	    --tag "gcr.io/cloud-marketplace-tools/k8s/deployer_helm_tiller/onbuild:$(MARKETPLACE_TOOLS_TAG)" \
+	    --build-arg FROM="$(REGISTRY)/k8s/deployer_helm_tiller:$(MARKETPLACE_TOOLS_TAG)" \
+	    --tag "$(REGISTRY)/k8s/deployer_helm_tiller/onbuild:$(MARKETPLACE_TOOLS_TAG)" \
 	    -f marketplace/deployer_helm_tiller_base/onbuild/Dockerfile \
 	    .
 	@touch "$@"


### PR DESCRIPTION
To allow for easy building (and reduced confusion with prod) of local images instead of hard-coded "gcr.io/cloud-marketplace-tools". Also reconcile with the existing behavior that the REGISTRY variable is printed during Make execution.

/gcbrun