### PR TITLE
Fixed rolebinding name created by deployer

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -234,7 +234,7 @@ def provision_kalm(schema, version_repo, app_name, namespace, deployer_image,
       'apiVersion': 'rbac.authorization.k8s.io/v1',
       'kind': 'RoleBinding',
       'metadata': {
-          'name': '{}-deployer-rb'.format(app_name),
+          'name': '{}:deployer-rb'.format(app_name),
           'namespace': namespace,
           'labels': labels,
       },
@@ -383,7 +383,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
       'apiVersion': 'rbac.authorization.k8s.io/v1',
       'kind': 'RoleBinding',
       'metadata': {
-          'name': '{}-deployer-rb'.format(app_name),
+          'name': '{}:deployer-rb'.format(app_name),
           'namespace': namespace,
           'labels': labels,
       },
@@ -425,7 +425,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'RoleBinding',
         'metadata': {
-            'name': '{}-deployer-rb{}'.format(app_name, i),
+            'name': '{}:deployer-rb{}'.format(app_name, i),
             'namespace': namespace,
             'labels': labels,
         },
@@ -467,7 +467,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'RoleBinding',
         'metadata': {
-            'name': limit_name('{}:{}-deployer-rb'.format(app_name, role), 64),
+            'name': limit_name('{}:{}:deployer-rb'.format(app_name, role), 64),
             'namespace': namespace,
             'labels': labels,
         },

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -383,7 +383,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
       'apiVersion': 'rbac.authorization.k8s.io/v1',
       'kind': 'RoleBinding',
       'metadata': {
-          'name': '{}:deployer-rb'.format(app_name),
+          'name': '{}-deployer-rb'.format(app_name),
           'namespace': namespace,
           'labels': labels,
       },
@@ -425,7 +425,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'RoleBinding',
         'metadata': {
-            'name': '{}:deployer-rb{}'.format(app_name, i),
+            'name': '{}-deployer-rb{}'.format(app_name, i),
             'namespace': namespace,
             'labels': labels,
         },
@@ -467,7 +467,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'RoleBinding',
         'metadata': {
-            'name': limit_name('{}:{}:deployer-rb'.format(app_name, role), 64),
+            'name': limit_name('{}:{}-deployer-rb'.format(app_name, role), 64),
             'namespace': namespace,
             'labels': labels,
         },


### PR DESCRIPTION
Fix for the issue with verification pipeline for some applications during ingestion. Role binding name created by deployer differs from the name it's trying to delete which causes verification failure.
`{namespace}-deployer-rb` != `{namespace}:deployer-rb`

Creation:
```
Step #3 - "Verify App": INFO Application 'apptest-u9d4g3r4' owns 'RoleBinding/apptest-u9d4g3r4:deployer-rb'
```

Deletion:
```
Step #3 - "Verify App": Error from server (NotFound): error when deleting "STDIN": rolebindings.rbac.authorization.k8s.io "apptest-u9d4g3r4-deployer-rb" not found
```

Full error log: https://pantheon.corp.google.com/cloud-build/builds/e89b26dd-6082-4c3b-b0be-b04c2c68b7c1?project=cloud-launcher-verifier-prd