### PR TITLE
Make deployer IAM resource naming consistent

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -383,7 +383,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
       'apiVersion': 'rbac.authorization.k8s.io/v1',
       'kind': 'RoleBinding',
       'metadata': {
-          'name': '{}:deployer-rb'.format(app_name),
+          'name': '{}-deployer-rb'.format(app_name),
           'namespace': namespace,
           'labels': labels,
       },
@@ -410,7 +410,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
     roles_and_rolebindings.append(default_rolebinding)
 
   for i, rules in enumerate(deployer_service_account.custom_role_rules()):
-    role_name = '{}:deployer-r{}'.format(app_name, i)
+    role_name = '{}-deployer-r{}'.format(app_name, i)
     roles_and_rolebindings.append({
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'Role',
@@ -425,7 +425,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'RoleBinding',
         'metadata': {
-            'name': '{}:deployer-rb{}'.format(app_name, i),
+            'name': '{}-deployer-rb{}'.format(app_name, i),
             'namespace': namespace,
             'labels': labels,
         },
@@ -467,7 +467,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
         'apiVersion': 'rbac.authorization.k8s.io/v1',
         'kind': 'RoleBinding',
         'metadata': {
-            'name': limit_name('{}:{}:deployer-rb'.format(app_name, role), 64),
+            'name': limit_name('{}:{}-deployer-rb'.format(app_name, role), 64),
             'namespace': namespace,
             'labels': labels,
         },

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -108,7 +108,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'RoleBinding',
                 'metadata': {
-                    'name': 'app-name-1:deployer-rb',
+                    'name': 'app-name-1-deployer-rb',
                     'namespace': 'namespace-1',
                     'labels': {
                         'some-key': 'some-value'
@@ -176,7 +176,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'Role',
                 'metadata': {
-                    'name': 'app-name-1:deployer-r0',
+                    'name': 'app-name-1-deployer-r0',
                     'namespace': 'namespace-1',
                     'labels': {
                         'some-key': 'some-value'
@@ -194,7 +194,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'RoleBinding',
                 'metadata': {
-                    'name': 'app-name-1:deployer-rb0',
+                    'name': 'app-name-1-deployer-rb0',
                     'namespace': 'namespace-1',
                     'labels': {
                         'some-key': 'some-value'
@@ -203,7 +203,7 @@ class ProvisionTest(unittest.TestCase):
                 'roleRef': {
                     'apiGroup': 'rbac.authorization.k8s.io',
                     'kind': 'Role',
-                    'name': 'app-name-1:deployer-r0',
+                    'name': 'app-name-1-deployer-r0',
                 },
                 'subjects': [{
                     'kind': 'ServiceAccount',
@@ -256,7 +256,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'RoleBinding',
                 'metadata': {
-                    'name': 'app-name-1:edit:deployer-rb',
+                    'name': 'app-name-1:edit-deployer-rb',
                     'namespace': 'namespace-1',
                     'labels': {
                         'some-key': 'some-value'
@@ -332,7 +332,7 @@ class ProvisionTest(unittest.TestCase):
                 'kind':
                     'RoleBinding',
                 'metadata': {
-                    'name': 'app-name-1:deployer-rb',
+                    'name': 'app-name-1-deployer-rb',
                     'namespace': 'namespace-1',
                     'labels': {
                         'some-key': 'some-value'


### PR DESCRIPTION
Replace the `<app-name>-deployer-r` pattern which was partially switched to `<app-name>:deployer-r` in [PR #381](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/pull/381/files)

/gcbrun