### PR TITLE
Validate SERVICE_ACCOUNT roles

### DIFF
--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -798,6 +798,12 @@ class SchemaXServiceAccount:
                                                      rule.get('apiGroups')):
             raise InvalidSchema("Missing or empty apiGroups in rules. "
                                 "Did you mean [\"v1\"] or [\"*\"]?")
+          if not rule.get('resources') or not filter(lambda x: x,
+                                                     rule.get('resources')):
+            raise InvalidSchema('Missing or empty resources in rules.')
+          if not rule.get('verbs') or not filter(lambda x: x,
+                                                 rule.get('verbs')):
+            raise InvalidSchema('Missing or empty verbs in rules.')
       else:
         raise InvalidSchema('rulesType must be one of PREDEFINED or CUSTOM')
 

--- a/marketplace/deployer_util/config_helper.py
+++ b/marketplace/deployer_util/config_helper.py
@@ -778,6 +778,28 @@ class SchemaXServiceAccount:
 
   def __init__(self, dictionary):
     self._roles = dictionary.get('roles', [])
+    for role in self._roles:
+      if role.get('rulesType') == 'PREDEFINED':
+        if role.get('rules'):
+          raise InvalidSchema('rules can only be used with rulesType CUSTOM')
+        if not role.get('rulesFromRoleName'):
+          raise InvalidSchema('Missing rulesFromRoleName for PREDEFINED role')
+      elif role.get('rulesType') == 'CUSTOM':
+        if role.get('rulesFromRoleName'):
+          raise InvalidSchema(
+              'rulesFromRoleName can only be used with rulesType PREDEFINED')
+        if not role.get('rules'):
+          raise InvalidSchema('Missing rules for CUSTOM role')
+        for rule in role.get('rules', []):
+          if rule.get('nonResourceURLs'):
+            raise InvalidSchema(
+                'Only attributes for resourceRules are supported in rules')
+          if not rule.get('apiGroups') or not filter(lambda x: x,
+                                                     rule.get('apiGroups')):
+            raise InvalidSchema("Missing or empty apiGroups in rules. "
+                                "Did you mean [\"v1\"] or [\"*\"]?")
+      else:
+        raise InvalidSchema('rulesType must be one of PREDEFINED or CUSTOM')
 
   def custom_role_rules(self):
     """Returns a list of rules for custom Roles."""

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -633,6 +633,129 @@ class ConfigHelperTest(unittest.TestCase):
         },
     ]], sa.custom_role_rules())
 
+  def test_service_account_predefined_rules(self):
+    with self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        'rules can only be used with rulesType CUSTOM'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesType: PREDEFINED
+                    rules:
+                    - apiGroups: ['']
+                      resources: ['Deployment']
+                      verbs: ['*']
+          """)
+
+  def test_service_account_predefined_missing_rulesFromRoleName(self):
+    with self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        'Missing rulesFromRoleName for PREDEFINED role'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesType: PREDEFINED
+          """)
+
+  def test_service_account_custom_rulesFromRoleName(self):
+    with self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        'rulesFromRoleName can only be used with rulesType PREDEFINED'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesType: CUSTOM
+                    rulesFromRoleName: edit
+          """)
+
+  def test_service_account_custom_nonResourceAttributes(self):
+    with self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        'Only attributes for resourceRules are supported in rules'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesType: CUSTOM
+                    rules:
+                    - nonResourceURLs: ['/version', '/healthz']
+                      verbs: ["get"]
+          """)
+
+  def test_service_account_custom_empty_apiGroups(self):
+    with self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        r'^Missing or empty apiGroups in rules. Did you mean'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesType: CUSTOM
+                    rules:
+                    - apiGroups: ['']
+                      resources: ['Pods']
+                      verbs: ['*']
+          """)
+
+  def test_service_account_custom_missingRules(self):
+    with self.assertRaisesRegexp(config_helper.InvalidSchema,
+                                 'Missing rules for CUSTOM role'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesType: CUSTOM
+          """)
+
+  def test_service_account_missing_rulesType(self):
+    with self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        'rulesType must be one of PREDEFINED or CUSTOM'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesFromRoleName: view
+          """)
+
   def test_storage_class(self):
     schema = config_helper.Schema.load_yaml("""
         properties:

--- a/marketplace/deployer_util/config_helper_test.py
+++ b/marketplace/deployer_util/config_helper_test.py
@@ -633,6 +633,22 @@ class ConfigHelperTest(unittest.TestCase):
         },
     ]], sa.custom_role_rules())
 
+  def test_service_account_missing_rulesType(self):
+    with self.assertRaisesRegexp(
+        config_helper.InvalidSchema,
+        'rulesType must be one of PREDEFINED or CUSTOM'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesFromRoleName: view
+          """)
+
   def test_service_account_predefined_rules(self):
     with self.assertRaisesRegexp(
         config_helper.InvalidSchema,
@@ -705,6 +721,21 @@ class ConfigHelperTest(unittest.TestCase):
                       verbs: ["get"]
           """)
 
+  def test_service_account_custom_missingRules(self):
+    with self.assertRaisesRegexp(config_helper.InvalidSchema,
+                                 'Missing rules for CUSTOM role'):
+      config_helper.Schema.load_yaml("""
+          properties:
+            sa:
+              type: string
+              x-google-marketplace:
+                type: SERVICE_ACCOUNT
+                serviceAccount:
+                  roles:
+                  - type: Role
+                    rulesType: CUSTOM
+          """)
+
   def test_service_account_custom_empty_apiGroups(self):
     with self.assertRaisesRegexp(
         config_helper.InvalidSchema,
@@ -725,9 +756,9 @@ class ConfigHelperTest(unittest.TestCase):
                       verbs: ['*']
           """)
 
-  def test_service_account_custom_missingRules(self):
+  def test_service_account_custom_empty_resources(self):
     with self.assertRaisesRegexp(config_helper.InvalidSchema,
-                                 'Missing rules for CUSTOM role'):
+                                 'Missing or empty resources in rules'):
       config_helper.Schema.load_yaml("""
           properties:
             sa:
@@ -738,12 +769,15 @@ class ConfigHelperTest(unittest.TestCase):
                   roles:
                   - type: Role
                     rulesType: CUSTOM
+                    rules:
+                    - apiGroups: ['v1']
+                      resources: ['']
+                      verbs: ['*']
           """)
 
-  def test_service_account_missing_rulesType(self):
-    with self.assertRaisesRegexp(
-        config_helper.InvalidSchema,
-        'rulesType must be one of PREDEFINED or CUSTOM'):
+  def test_service_account_custom_empty_verbs(self):
+    with self.assertRaisesRegexp(config_helper.InvalidSchema,
+                                 'Missing or empty verbs in rules'):
       config_helper.Schema.load_yaml("""
           properties:
             sa:
@@ -753,7 +787,11 @@ class ConfigHelperTest(unittest.TestCase):
                 serviceAccount:
                   roles:
                   - type: Role
-                    rulesFromRoleName: view
+                    rulesType: CUSTOM
+                    rules:
+                    - apiGroups: ['v1']
+                      resources: ['Pods']
+                      verbs: ['']
           """)
 
   def test_storage_class(self):


### PR DESCRIPTION
Ensure that SERVICE_ACCOUNT properties are validly formed to catch errors early. Otherwise, issues only surface when the property is parsed in the UI.

/gcbrun