### PR TITLE
Use latest Helm version - 2.16.1, which supports ternary function.

### DIFF
--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -33,7 +33,7 @@ RUN ln -s /opt/kubectl/1.14 /opt/kubectl/default
 
 RUN mkdir -p /bin/helm-downloaded \
     && wget -q -O /bin/helm-downloaded/helm.tar.gz \
-        https://storage.googleapis.com/kubernetes-helm/helm-v2.8.1-linux-amd64.tar.gz \
+        https://storage.googleapis.com/kubernetes-helm/helm-v2.16.1-linux-amd64.tar.gz \
     && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
     && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
     && rm -rf /bin/helm-downloaded


### PR DESCRIPTION
Helm 2.8.1 doesn't support ternary in YAML files. 
In this example, used by Postgres chart (https://github.com/helm/charts/blob/master/stable/postgresql/templates/statefulset.yaml, rows 121 and 202) ternary won't be parsed and deployment will fail. 
```value: {{ ternary "true" "false" .Values.image.debug | quote }}```

Error message: "Error: parse error in "artifactory-ha/charts/postgresql/templates/statefulset.yaml": template: artifactory-ha/charts/postgresql/templates/statefulset.yaml:121: function "ternary" not defined"

To resolve this problem we need to use the latest version of Helm in the Deployer dockerfile. 