### PR TITLE
Make OwnerRefs handle cleanup of deployer's RBAC resources

### DIFF
--- a/marketplace/deployer_util/clean_iam_resources.sh
+++ b/marketplace/deployer_util/clean_iam_resources.sh
@@ -20,6 +20,8 @@ set -eox pipefail
 [[ -z "$NAMESPACE" ]] && echo "NAMESPACE must be set" && exit 1
 
 # Delete the service account (which owns its RBAC objects) by label.
+# Update _DEPLOYER_OWNED_KINDS in set_ownership.py to delete additional
+# resource types besides Role and RoleBinding.
 # Note that only resources of a one-shot deployer have this label.
 # Resources of a KALM-managed deployer have
 # app.kubernetes.io/component=kalm.marketplace.cloud.google.com label.

--- a/marketplace/deployer_util/clean_iam_resources.sh
+++ b/marketplace/deployer_util/clean_iam_resources.sh
@@ -19,12 +19,11 @@ set -eox pipefail
 [[ -z "$NAME" ]] && echo "NAME must be set" && exit 1
 [[ -z "$NAMESPACE" ]] && echo "NAMESPACE must be set" && exit 1
 
-# Delete the service account and RBAC objects by labels.
+# Delete the service account (which owns its RBAC objects) by label.
 # Note that only resources of a one-shot deployer have this label.
 # Resources of a KALM-managed deployer have
 # app.kubernetes.io/component=kalm.marketplace.cloud.google.com label.
-# TODO(#347): Only delete the ServiceAccount once it owns the Role{,Binding}
 kubectl delete --namespace="$NAMESPACE" \
-  ServiceAccount,Role,RoleBinding \
+  ServiceAccount \
   -l 'app.kubernetes.io/component'='deployer.marketplace.cloud.google.com','app.kubernetes.io/name'="$NAME" \
   --ignore-not-found

--- a/marketplace/deployer_util/magic_schema.sh
+++ b/marketplace/deployer_util/magic_schema.sh
@@ -39,7 +39,7 @@ namespace_key="$(/bin/extract_schema_key.py --type NAMESPACE)"
 # Provisioned manifests are inserted into the original schema
 # under top-level __manifests__ field.
 printf '{%s: "m4g1cn8m3", %s: "m4g1cn8m32p4c3"}' "${name_key}" "${namespace_key}" \
-  | /bin/provision.py --values_mode=stdin --deployer_image="${deployer}" \
+  | /bin/provision.py --values_mode=stdin --deployer_image="${deployer}" --deployer_service_account_name='m4g1cn8m3-deployer-sa' \
   | /bin/set_app_labels.py --manifests=- --dest=- --name="m4g1cn8m3" --namespace="m4g1cn8m32p4c3" \
   | /bin/yaml2json \
   | jq -s . \

--- a/marketplace/deployer_util/make_dns1123_name.py
+++ b/marketplace/deployer_util/make_dns1123_name.py
@@ -56,3 +56,7 @@ def limit_name(name, length=127):
     h4sh = m.hexdigest()[:4]
     result = '{}-{}'.format(result, h4sh)
   return result
+
+
+if __name__ == "__main__":
+  main()

--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -21,7 +21,7 @@ import yaml
 import log_util as log
 
 from argparse import ArgumentParser
-from resources import set_app_resource_ownership
+from resources import set_app_resource_ownership, set_service_account_resource_ownership
 from yaml_util import load_resources_yaml
 from yaml_util import parse_resources_yaml
 
@@ -54,6 +54,7 @@ _CLUSTER_SCOPED_KINDS = [
     "StorageClass",
     "VolumeAttachment",
 ]
+_DEPLOYER_OWNED_KINDS = ["Role", "RoleBinding"]
 
 
 def main():
@@ -66,6 +67,16 @@ def main():
       "--app_api_version",
       help="The apiVersion of the Application CRD",
       required=True)
+  parser.add_argument(
+      "--deployer_name",
+      help="The name of the deployer service account instance. "
+      "If deployer_uid is also set, the deployer service account is set "
+      "as the owner of namespaced deployer components.")
+  parser.add_argument(
+      "--deployer_uid",
+      help="The uid of the deployer service account instance. "
+      "If deployer_name is also set, the deployer service account is set "
+      "as the owner of namespaced deployer components.")
   parser.add_argument(
       "--manifests",
       help="The folder containing the manifest templates, "
@@ -118,7 +129,9 @@ def main():
         included_kinds,
         app_name=args.app_name,
         app_uid=args.app_uid,
-        app_api_version=args.app_api_version)
+        app_api_version=args.app_api_version,
+        deployer_name=args.deployer_name,
+        deployer_uid=args.deployer_uid)
     sys.stdout.flush()
   else:
     with open(args.dest, "w") as outfile:
@@ -128,11 +141,13 @@ def main():
           included_kinds,
           app_name=args.app_name,
           app_uid=args.app_uid,
-          app_api_version=args.app_api_version)
+          app_api_version=args.app_api_version,
+          deployer_name=args.deployer_name,
+          deployer_uid=args.deployer_uid)
 
 
-def dump(outfile, resources, included_kinds, app_name, app_uid,
-         app_api_version):
+def dump(outfile, resources, included_kinds, app_name, app_uid, app_api_version,
+         deployer_name, deployer_uid):
 
   def maybe_assign_ownership(resource):
     if resource["kind"] in _CLUSTER_SCOPED_KINDS:
@@ -151,10 +166,28 @@ def dump(outfile, resources, included_kinds, app_name, app_uid,
           app_api_version=app_api_version,
           resource=resource)
 
+    if deployer_name and deployer_uid and should_be_deployer_owned(resource):
+      log.info("ServiceAccount '{:s}' owns '{:s}/{:s}'", deployer_name,
+               resource["kind"], resource["metadata"]["name"])
+      resource = copy.deepcopy(resource)
+      set_service_account_resource_ownership(
+          account_uid=deployer_uid,
+          account_name=deployer_name,
+          resource=resource)
+
     return resource
 
   to_be_dumped = [maybe_assign_ownership(resource) for resource in resources]
   yaml.safe_dump_all(to_be_dumped, outfile, default_flow_style=False, indent=2)
+
+
+def should_be_deployer_owned(resource):
+  if not resource["kind"] in _DEPLOYER_OWNED_KINDS:
+    return False
+  if resource.get("metadata", {}).get("labels", {}).get(
+      "app.kubernetes.io/component") != "deployer.marketplace.cloud.google.com":
+    return False
+  return True
 
 
 if __name__ == "__main__":

--- a/scripts/install
+++ b/scripts/install
@@ -114,14 +114,30 @@ app_uid=$(kubectl get "applications.app.k8s.io/$name" \
   --namespace="$namespace" \
   --output=jsonpath='{.metadata.uid}')
 
+# Create ServiceAccount instance.
+deployer_name="$(make_dns1123_name.py --name="${name}")-deployer-sa"
+kubectl apply --namespace="$namespace" --filename=- <<EOF
+apiVersion: "v1"
+kind: ServiceAccount
+metadata:
+  name: "${deployer_name}"
+  namespace: "${namespace}"
+EOF
+
+deployer_uid=$(kubectl get sa ${deployer_name} \
+  --namespace="$namespace" \
+  --output=jsonpath='{.metadata.uid}')
+
 # Provisions external resource dependencies and the deployer resources.
-# We set the application as the owner for all of the namespaced resources.
+# We set the application as the owner for all of the namespaced resources,
+# and the deployer as the owner of it's dependent RBAC resources.
 manifest_dir="/tmp/${namespace}_${name}_$(date +'%Y-%m-%d_%H-%M-%S')"
 echo "${parameters}" \
   | provision.py \
     --values_mode=stdin \
     --deployer_image="${deployer}" \
     --deployer_entrypoint="${entrypoint}" \
+    --deployer_service_account_name="${deployer_name}" \
     --version_repo="${version_repo}" \
     --image_pull_secret="${image_pull_secret}" \
   | set_app_labels.py \
@@ -135,7 +151,9 @@ echo "${parameters}" \
     --noapp \
     --app_name="${name}" \
     --app_uid="${app_uid}" \
-    --app_api_version="${app_version}"
+    --app_api_version="${app_version}" \
+    --deployer_name="${deployer_name}" \
+    --deployer_uid="${deployer_uid}"
 
 echo "INFO: Applying the following manifests:"
 cat "${manifest_dir}"

--- a/scripts/install
+++ b/scripts/install
@@ -115,16 +115,16 @@ app_uid=$(kubectl get "applications.app.k8s.io/$name" \
   --output=jsonpath='{.metadata.uid}')
 
 # Create ServiceAccount instance.
-deployer_name="$(make_dns1123_name.py --name="${name}")-deployer-sa"
+deployer_service_account_name="$(make_dns1123_name.py --name="${name}")-deployer-sa"
 kubectl apply --namespace="$namespace" --filename=- <<EOF
 apiVersion: "v1"
 kind: ServiceAccount
 metadata:
-  name: "${deployer_name}"
+  name: "${deployer_service_account_name}"
   namespace: "${namespace}"
 EOF
 
-deployer_uid=$(kubectl get sa ${deployer_name} \
+deployer_uid=$(kubectl get sa ${deployer_service_account_name} \
   --namespace="$namespace" \
   --output=jsonpath='{.metadata.uid}')
 
@@ -137,7 +137,7 @@ echo "${parameters}" \
     --values_mode=stdin \
     --deployer_image="${deployer}" \
     --deployer_entrypoint="${entrypoint}" \
-    --deployer_service_account_name="${deployer_name}" \
+    --deployer_service_account_name="${deployer_service_account_name}" \
     --version_repo="${version_repo}" \
     --image_pull_secret="${image_pull_secret}" \
   | set_app_labels.py \
@@ -152,7 +152,7 @@ echo "${parameters}" \
     --app_name="${name}" \
     --app_uid="${app_uid}" \
     --app_api_version="${app_version}" \
-    --deployer_name="${deployer_name}" \
+    --deployer_name="${deployer_service_account_name}" \
     --deployer_uid="${deployer_uid}"
 
 echo "INFO: Applying the following manifests:"

--- a/scripts/install
+++ b/scripts/install
@@ -130,7 +130,7 @@ deployer_uid=$(kubectl get sa ${deployer_name} \
 
 # Provisions external resource dependencies and the deployer resources.
 # We set the application as the owner for all of the namespaced resources,
-# and the deployer as the owner of it's dependent RBAC resources.
+# and the deployer as the owner of its dependent RBAC resources.
 manifest_dir="/tmp/${namespace}_${name}_$(date +'%Y-%m-%d_%H-%M-%S')"
 echo "${parameters}" \
   | provision.py \


### PR DESCRIPTION
Set the deployer service account as owner of it's component resources (i.e. Role and RoleBinding) during install (already done during UI deployment), then only delete the deployer ServiceAccount after deployment, rather than also explicitly deleting the Role and Rolebinding.

Addresses #347:
Partners must update their base deployer to take advantage of this change, which is to only delete the deployer service account after deployment instead of also attempting to delete its dependent resources to avoid deletion timing problems.

/gcbrun