### PR TITLE
Setting required cpu and memory values for the deployer

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -295,6 +295,12 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
                 'subPath': 'values.yaml',
                 'readOnly': True,
             },],
+            'resources': {
+                'requests': {
+                    'memory': '\"42Mi\"',
+                    'cpu': '\"150m\"'
+                }
+            },
         },],
         'restartPolicy':
             'Never',
@@ -321,6 +327,12 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
                 'name': 'config-volume',
                 'mountPath': '/data/values',
             },],
+            'resources': {
+                'requests': {
+                    'memory': '\"42Mi\"',
+                    'cpu': '\"150m\"'
+                }
+            },
         },],
         'restartPolicy':
             'Never',


### PR DESCRIPTION
The deployer can sometimes run into the issue where the cluster does not have enough available resources for it to run successfully. This is setting a minimum value for the cpu and memory to handle this.