### PR TITLE
Setting minimum required cpu and memory values for the deployer

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -275,12 +275,7 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
       'app.kubernetes.io/component': 'deployer.marketplace.cloud.google.com',
       'marketplace.cloud.google.com/deployer': 'Main',
   }
-  resources_requests = {
-      'requests': {
-          'memory': '100Mi',
-          'cpu': '100m'
-      }
-  }
+  resources_requests = {'requests': {'memory': '100Mi', 'cpu': '100m'}}
 
   if schema.is_v2():
     config = make_v2_config(schema, deployer_image, namespace, app_name, labels,

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -294,8 +294,8 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
             },],
             'resources': {
                 'requests': {
-                    'memory': '42Mi',
-                    'cpu': '150m'
+                    'memory': '2Mi',
+                    'cpu': '1m'
                 }
             },
         },],
@@ -323,8 +323,8 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
             },],
             'resources': {
                 'requests': {
-                    'memory': '42Mi',
-                    'cpu': '150m'
+                    'memory': '2Mi',
+                    'cpu': '1m'
                 }
             },
         },],

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -275,6 +275,12 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
       'app.kubernetes.io/component': 'deployer.marketplace.cloud.google.com',
       'marketplace.cloud.google.com/deployer': 'Main',
   }
+  resources_requests = {
+      'requests': {
+          'memory': '100Mi',
+          'cpu': '100m'
+      }
+  }
 
   if schema.is_v2():
     config = make_v2_config(schema, deployer_image, namespace, app_name, labels,
@@ -292,12 +298,7 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
                 'subPath': 'values.yaml',
                 'readOnly': True,
             },],
-            'resources': {
-                'requests': {
-                    'memory': '100Mi',
-                    'cpu': '100m'
-                }
-            },
+            'resources': resources_requests,
         },],
         'restartPolicy':
             'Never',
@@ -321,12 +322,7 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
                 'name': 'config-volume',
                 'mountPath': '/data/values',
             },],
-            'resources': {
-                'requests': {
-                    'memory': '100Mi',
-                    'cpu': '100m'
-                }
-            },
+            'resources': resources_requests,
         },],
         'restartPolicy':
             'Never',

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -294,8 +294,8 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
             },],
             'resources': {
                 'requests': {
-                    'memory': '2Mi',
-                    'cpu': '1m'
+                    'memory': '100Mi',
+                    'cpu': '100m'
                 }
             },
         },],
@@ -323,8 +323,8 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
             },],
             'resources': {
                 'requests': {
-                    'memory': '2Mi',
-                    'cpu': '1m'
+                    'memory': '100Mi',
+                    'cpu': '100m'
                 }
             },
         },],

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -283,18 +283,21 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
         'serviceAccountName':
             deployer_service_account_name,
         'containers': [{
-            'name':
-                'deployer',
-            'image':
-                deployer_image,
-            'imagePullPolicy':
-                'Always',
+            'name': 'deployer',
+            'image': deployer_image,
+            'imagePullPolicy': 'Always',
             'volumeMounts': [{
                 'name': 'config-volume',
                 'mountPath': '/data/values.yaml',
                 'subPath': 'values.yaml',
                 'readOnly': True,
             },],
+            'resources': {
+                'requests': {
+                    'memory': '42Mi',
+                    'cpu': '150m'
+                }
+            },
         },],
         'restartPolicy':
             'Never',
@@ -311,16 +314,19 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
         'serviceAccountName':
             deployer_service_account_name,
         'containers': [{
-            'name':
-                'deployer',
-            'image':
-                deployer_image,
-            'imagePullPolicy':
-                'Always',
+            'name': 'deployer',
+            'image': deployer_image,
+            'imagePullPolicy': 'Always',
             'volumeMounts': [{
                 'name': 'config-volume',
                 'mountPath': '/data/values',
             },],
+            'resources': {
+                'requests': {
+                    'memory': '42Mi',
+                    'cpu': '150m'
+                }
+            },
         },],
         'restartPolicy':
             'Never',


### PR DESCRIPTION
The deployer will encounter errors if there aren't enough resources
for it to run successfully. This sets the minimum values for the
deployer:

- cpu: 1m
- memory: 2Mi