### PR TITLE
Revert deployer permissions to  in namespace

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -381,55 +381,25 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
       'name': sa_name,
       'namespace': namespace,
   }]
-  app_edit_role_name = '{}-deployer-app-edit-r'.format(app_name)
-  default_role_and_rolebindings = [{
+  default_rolebinding = {
       'apiVersion': 'rbac.authorization.k8s.io/v1',
       'kind': 'RoleBinding',
       'metadata': {
-          'name': '{}-deployer-admin-rb'.format(app_name),
+          'name': '{}-deployer-rb'.format(app_name),
           'namespace': namespace,
           'labels': labels,
       },
       'roleRef': {
           'apiGroup': 'rbac.authorization.k8s.io',
           'kind': 'ClusterRole',
-          'name': 'admin',
+          'name': 'cluster-admin',
       },
       'subjects': subjects,
-  }, {
-      'apiVersion':
-          'rbac.authorization.k8s.io/v1',
-      'kind':
-          'Role',
-      'metadata': {
-          'name': app_edit_role_name,
-          'namespace': namespace,
-          'labels': labels,
-      },
-      'rules': [{
-          'apiGroups': ['app.k8s.io'],
-          'resources': ['applications'],
-          'verbs': ['*'],
-      }],
-  }, {
-      'apiVersion': 'rbac.authorization.k8s.io/v1',
-      'kind': 'RoleBinding',
-      'metadata': {
-          'name': '{}-deployer-app-edit-rb'.format(app_name),
-          'namespace': namespace,
-          'labels': labels,
-      },
-      'roleRef': {
-          'apiGroup': 'rbac.authorization.k8s.io',
-          'kind': 'Role',
-          'name': app_edit_role_name,
-      },
-      'subjects': subjects,
-  }]
+  }
 
   if not schema.is_v2(
   ) or not schema.x_google_marketplace.deployer_service_account:
-    return default_role_and_rolebindings
+    return [default_rolebinding]
 
   roles_and_rolebindings = []
   deployer_service_account = schema.x_google_marketplace.deployer_service_account
@@ -437,7 +407,7 @@ def make_deployer_rolebindings(schema, namespace, app_name, labels, sa_name):
   # Set the default rolebinding if no namespace roles are defined
   if not deployer_service_account.custom_role_rules(
   ) and not deployer_service_account.predefined_roles():
-    roles_and_rolebindings.extend(default_role_and_rolebindings)
+    roles_and_rolebindings.append(default_rolebinding)
 
   for i, rules in enumerate(deployer_service_account.custom_role_rules()):
     role_name = '{}-deployer-r{}'.format(app_name, i)

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -98,14 +98,14 @@ class ProvisionTest(unittest.TestCase):
       """)
     self.assertEqual(
         [
-            # The default namespace role/rolebindings should be created
+            # The default namespace rolebinding should be created
             {
                 'apiVersion':
                     'rbac.authorization.k8s.io/v1',
                 'kind':
                     'RoleBinding',
                 'metadata': {
-                    'name': 'app-name-1-deployer-admin-rb',
+                    'name': 'app-name-1-deployer-rb',
                     'namespace': 'namespace-1',
                     'labels': {
                         'some-key': 'some-value'
@@ -115,49 +115,7 @@ class ProvisionTest(unittest.TestCase):
                     'apiGroup': 'rbac.authorization.k8s.io',
                     # Note: predefined ones are actually cluster roles.
                     'kind': 'ClusterRole',
-                    'name': 'admin',
-                },
-                'subjects': [{
-                    'kind': 'ServiceAccount',
-                    'name': 'app-name-deployer-sa',
-                    'namespace': 'namespace-1',
-                }],
-            },
-            {
-                'apiVersion':
-                    'rbac.authorization.k8s.io/v1',
-                'kind':
-                    'Role',
-                'metadata': {
-                    'name': 'app-name-1-deployer-app-edit-r',
-                    'namespace': 'namespace-1',
-                    'labels': {
-                        'some-key': 'some-value'
-                    },
-                },
-                'rules': [{
-                    'apiGroups': ['app.k8s.io'],
-                    'resources': ['applications'],
-                    'verbs': ['*'],
-                }],
-            },
-            {
-                'apiVersion':
-                    'rbac.authorization.k8s.io/v1',
-                'kind':
-                    'RoleBinding',
-                'metadata': {
-                    'name': 'app-name-1-deployer-app-edit-rb',
-                    'namespace': 'namespace-1',
-                    'labels': {
-                        'some-key': 'some-value'
-                    },
-                },
-                'roleRef': {
-                    'apiGroup': 'rbac.authorization.k8s.io',
-                    # Note: predefined ones are actually cluster roles.
-                    'kind': 'Role',
-                    'name': 'app-name-1-deployer-app-edit-r',
+                    'name': 'cluster-admin',
                 },
                 'subjects': [{
                     'kind': 'ServiceAccount',
@@ -364,14 +322,14 @@ class ProvisionTest(unittest.TestCase):
       """)
     self.assertCountEqual(
         [
-            # The default namespace role/rolebindings should also be created
+            # The default namespace rolebinding should also be created
             {
                 'apiVersion':
                     'rbac.authorization.k8s.io/v1',
                 'kind':
                     'RoleBinding',
                 'metadata': {
-                    'name': 'app-name-1-deployer-admin-rb',
+                    'name': 'app-name-1-deployer-rb',
                     'namespace': 'namespace-1',
                     'labels': {
                         'some-key': 'some-value'
@@ -381,49 +339,7 @@ class ProvisionTest(unittest.TestCase):
                     'apiGroup': 'rbac.authorization.k8s.io',
                     # Note: predefined ones are actually cluster roles.
                     'kind': 'ClusterRole',
-                    'name': 'admin',
-                },
-                'subjects': [{
-                    'kind': 'ServiceAccount',
-                    'name': 'app-name-deployer-sa',
-                    'namespace': 'namespace-1',
-                }],
-            },
-            {
-                'apiVersion':
-                    'rbac.authorization.k8s.io/v1',
-                'kind':
-                    'Role',
-                'metadata': {
-                    'name': 'app-name-1-deployer-app-edit-r',
-                    'namespace': 'namespace-1',
-                    'labels': {
-                        'some-key': 'some-value'
-                    },
-                },
-                'rules': [{
-                    'apiGroups': ['app.k8s.io'],
-                    'resources': ['applications'],
-                    'verbs': ['*'],
-                }],
-            },
-            {
-                'apiVersion':
-                    'rbac.authorization.k8s.io/v1',
-                'kind':
-                    'RoleBinding',
-                'metadata': {
-                    'name': 'app-name-1-deployer-app-edit-rb',
-                    'namespace': 'namespace-1',
-                    'labels': {
-                        'some-key': 'some-value'
-                    },
-                },
-                'roleRef': {
-                    'apiGroup': 'rbac.authorization.k8s.io',
-                    # Note: predefined ones are actually cluster roles.
-                    'kind': 'Role',
-                    'name': 'app-name-1-deployer-app-edit-r',
+                    'name': 'cluster-admin',
                 },
                 'subjects': [{
                     'kind': 'ServiceAccount',


### PR DESCRIPTION
Due to apps failing for `unknown` permission failures.

Created by checking out the modified files from the previous commit:
```shell
git checkout 5749bf28fdcd320074348513c22855f88734ce37 marketplace/deployer_util/provision.py
git checkout 5749bf28fdcd320074348513c22855f88734ce37 marketplace/deployer_util/provision_test.py

```
/gcbrun