### PR TITLE
Update yapf style name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ format/py: .build/tests/py
 	  -v $(PWD):/data \
 	  --entrypoint python3 \
 	  tests/py \
-	  -m yapf --style chromium --recursive --in-place \
+	  -m yapf --style yapf --recursive --in-place \
 	  --exclude "data/vendor/" \
 	  --verbose --parallel \
 	  "/data"


### PR DESCRIPTION
To fix `make format/py` (https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/issues/503)

/gcbrun

