### PR TITLE
Update cleanup for deployer-owned RBAC resources

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -362,7 +362,7 @@ def provision_deployer(schema, app_name, namespace, deployer_image,
           'metadata': {
               'name': "{}-deployer".format(app_name),
               'namespace': namespace,
-              'labels': dependents_labels,
+              'labels': job_labels,
           },
           'spec': {
               'template': {

--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -150,16 +150,8 @@ def dump(outfile, resources, included_kinds, app_name, app_uid, app_api_version,
       log.info("Application '{:s}' does not own cluster-scoped '{:s}/{:s}'",
                app_name, resource["kind"], resource["metadata"]["name"])
 
-    if included_kinds is None or resource["kind"] in included_kinds:
-      log.info("Application '{:s}' owns '{:s}/{:s}'", app_name,
-               resource["kind"], resource["metadata"]["name"])
-      resource = copy.deepcopy(resource)
-      set_app_resource_ownership(
-          app_uid=app_uid,
-          app_name=app_name,
-          app_api_version=app_api_version,
-          resource=resource)
-
+    # Deployer-owned resources should not be owned by the Application, as
+    # they should be deleted with the deployer service account (not the app).
     if deployer_name and deployer_uid and should_be_deployer_owned(resource):
       log.info("ServiceAccount '{:s}' owns '{:s}/{:s}'", deployer_name,
                resource["kind"], resource["metadata"]["name"])
@@ -167,6 +159,15 @@ def dump(outfile, resources, included_kinds, app_name, app_uid, app_api_version,
       set_service_account_resource_ownership(
           account_uid=deployer_uid,
           account_name=deployer_name,
+          resource=resource)
+    elif included_kinds is None or resource["kind"] in included_kinds:
+      log.info("Application '{:s}' owns '{:s}/{:s}'", app_name,
+               resource["kind"], resource["metadata"]["name"])
+      resource = copy.deepcopy(resource)
+      set_app_resource_ownership(
+          app_uid=app_uid,
+          app_name=app_name,
+          app_api_version=app_api_version,
           resource=resource)
 
     return resource


### PR DESCRIPTION
1. Change label for deployer-owned RBAC resources so that the deployer does not attempt to delete them manually (causes https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/issues/347), leaving cleanup to OwnerRefs
2. Only set the deployer ServiceAccount as owner of deployer-wned RBAC resources (instead of also setting the Application as owner) so that they are cleaned up along with the deployer ServiceAccount instead of only on Application deletion (as deletion occurs only when all owners have been deleted; see [API reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta)).

/gcbrun