### PR TITLE
Set the namespace as owner of cluster-scoped resources in verify

### DIFF
--- a/marketplace/deployer_util/deploy_with_tests.sh
+++ b/marketplace/deployer_util/deploy_with_tests.sh
@@ -63,6 +63,8 @@ app_uid=$(kubectl get "applications.app.k8s.io/$NAME" \
 app_api_version=$(kubectl get "applications.app.k8s.io/$NAME" \
   --namespace="$NAMESPACE" \
   --output=jsonpath='{.apiVersion}')
+namespace_uid=$(kubectl get "namespaces/$NAMESPACE" \
+  --output=jsonpath='{.metadata.uid}')
 
 /bin/expand_config.py --values_mode raw --app_uid "$app_uid"
 
@@ -73,6 +75,8 @@ create_manifests.sh --mode="test"
   --app_name "$NAME" \
   --app_uid "$app_uid" \
   --app_api_version "$app_api_version" \
+  --namespace "$NAMESPACE" \
+  --namespace_uid "$namespace_uid" \
   --manifests "/data/manifest-expanded" \
   --dest "/data/resources.yaml"
 

--- a/marketplace/deployer_util/resources.py
+++ b/marketplace/deployer_util/resources.py
@@ -24,6 +24,10 @@ def set_service_account_resource_ownership(account_uid, account_name, resource):
   set_resource_ownership(account_uid, account_name, "v1", "ServiceAccount",
                          resource)
 
+def set_namespace_resource_ownership(namespace_uid, namespace_name, resource):
+  """ Set the namespace as owner of the resource"""
+  set_resource_ownership(namespace_uid, namespace_name, "v1", "Namespace",
+                         resource)
 
 def set_resource_ownership(owner_uid, owner_name, owner_api_version, owner_kind,
                            resource):

--- a/marketplace/deployer_util/resources.py
+++ b/marketplace/deployer_util/resources.py
@@ -24,10 +24,12 @@ def set_service_account_resource_ownership(account_uid, account_name, resource):
   set_resource_ownership(account_uid, account_name, "v1", "ServiceAccount",
                          resource)
 
+
 def set_namespace_resource_ownership(namespace_uid, namespace_name, resource):
   """ Set the namespace as owner of the resource"""
   set_resource_ownership(namespace_uid, namespace_name, "v1", "Namespace",
                          resource)
+
 
 def set_resource_ownership(owner_uid, owner_name, owner_api_version, owner_kind,
                            resource):

--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -84,7 +84,7 @@ def main():
       help="The namespace containing the application. "
       "If namespace_uid is also set, the namespace is set as the owner"
       "of cluster-scoped resources (otherwise unowned).")
-    parser.add_argument(
+  parser.add_argument(
       "--namespace_uid",
       help="The namespace containing the application. "
       "If namespace is also set, the namespace is set as the owner"
@@ -132,6 +132,7 @@ def main():
         resources,
         included_kinds,
         namespace=args.namespace,
+        namespace_uid=args.namespace_uid,
         app_name=args.app_name,
         app_uid=args.app_uid,
         app_api_version=args.app_api_version,
@@ -145,6 +146,7 @@ def main():
           resources,
           included_kinds,
           namespace=args.namespace,
+          namespace_uid=args.namespace_uid,
           app_name=args.app_name,
           app_uid=args.app_uid,
           app_api_version=args.app_api_version,
@@ -152,8 +154,8 @@ def main():
           deployer_uid=args.deployer_uid)
 
 
-def dump(outfile, resources, included_kinds, namespace, app_name, app_uid, app_api_version,
-         deployer_name, deployer_uid):
+def dump(outfile, resources, included_kinds, namespace, namespace_uid, app_name,
+         app_uid, app_api_version, deployer_name, deployer_uid):
 
   def maybe_assign_ownership(resource):
     if resource["kind"] in _CLUSTER_SCOPED_KINDS:
@@ -161,12 +163,13 @@ def dump(outfile, resources, included_kinds, namespace, app_name, app_uid, app_a
       # https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents
       # Set the namespace as owner if provided, otherwise leave unowned.
       if namespace and namespace_uid:
-        log.info("Namespace '{:s}' owns '{:s}/{:s}'", namespace,resource["kind"], resource["metadata"]["name"])
+        log.info("Namespace '{:s}' owns '{:s}/{:s}'", namespace,
+                 resource["kind"], resource["metadata"]["name"])
         set_namespace_resource_ownership(
             namespace_uid=namespace_uid,
             namespace_name=namespace,
             resource=resource)
-      elif:
+      else:
         log.info("Application '{:s}' does not own cluster-scoped '{:s}/{:s}'",
                  app_name, resource["kind"], resource["metadata"]["name"])
 

--- a/marketplace/deployer_util/set_ownership.py
+++ b/marketplace/deployer_util/set_ownership.py
@@ -23,6 +23,7 @@ import log_util as log
 from argparse import ArgumentParser
 from resources import find_application_resource
 from resources import set_app_resource_ownership
+from resources import set_namespace_resource_ownership
 from resources import set_service_account_resource_ownership
 from yaml_util import load_resources_yaml
 from yaml_util import parse_resources_yaml


### PR DESCRIPTION
To prevent leaving orphaned resources in `mpdev verify`, improving the reliability of tests.

No update to `mpdev install` or end-user flows, as the desired handling of cluster-scoped resources is unclear.

/gcbrun