### PR TITLE
Allow scripts/verify to consume parameters from GCS

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -165,6 +165,14 @@ docker run \
     --rm "${deployer}" \
     -c 'cat /data/schema.yaml' \
 > /data/schema.yaml
+
+# If parameters is a gcs file, use the content of the file instead
+if [[ "$parameters" = "gs://"* ]]; then
+  echo "Using parameters from $parameters"
+  parameters="$(gsutil cat $parameters)"
+  echo "$parameters"
+fi
+
 echo "$parameters" \
   | json2yaml \
 > /data/values.yaml


### PR DESCRIPTION
Cloud build has a limit of 4k characters in the command line. All the images need to be overwritten in the parameters, which can cause the character limit to be reached for a few solutions.

This reduces the number of characters in the parameters to avoid the limit.