### PR TITLE
Refer to 'double' instead of 'float'

### DIFF
--- a/docs/billing-integration.md
+++ b/docs/billing-integration.md
@@ -113,7 +113,7 @@ data:
     # e.g. metric may be reported in MiBy/min but priced in GiBy/day
     #
     # If the reporting metric is not more granular than the pricing
-    # metric (which is recommended), a float type is likely needed
+    # metric (which is recommended), a double type is likely needed
     # in order to provide sufficient precision.
     - name: test_app_data_miby_min
       type: int


### PR DESCRIPTION
As the metric type should be `double` instead of `float` ([example](https://github.com/GoogleCloudPlatform/ubbagent/blob/b20a3bf0ac380ad27c02141d4d528de5175424a1/metrics/report_test.go#L32)).

/gcbrun