### PR TITLE
Update schema docs for restricted SERVICE_ACCOUNT permissions

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -547,10 +547,18 @@ All service accounts need to be defined as parameters in `schema.yaml`.
 
 If you add a Kubernetes `ServiceAccount` as a resource in your manifest, the
 deployment fails with an authentication error, because the deployer doesn't run
-with enough privileges to create a Service Account. When permissions involve
-modifying resources, custom roles are prefered over predefined roles.
+with enough privileges to create a Service Account by default.
 
-For example, the following `schema.yaml` snippet adds a Service Account with
+When permissions involve modifying resources, custom roles are prefered over
+predefined roles. In accordance with the principle of least privilege, predefined
+`cluster-admin`, `admin`, and `edit` are not supported as cluster-scoped roles;
+`CUSTOM` roles defining specific rules must be used instead.
+
+If you only need to create cluster-scoped resources to initialize (vs. run)
+your app, specify these permissions in the
+[`deployerServiceAccount`](#deployerserviceaccount) field instead.
+
+The following `schema.yaml` example snippet adds a Service Account with
 Cluster Roles:
 
 ```yaml
@@ -584,6 +592,7 @@ properties:
 The `description` field (required) should indicate the service account's purpose
 and explain why it needs the requested permissions, particularly cluster-scoped
 permissions. It may be shown to users in the UI.
+
 
 #### type: STORAGE_CLASS
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -593,7 +593,6 @@ The `description` field (required) should indicate the service account's purpose
 and explain why it needs the requested permissions, particularly cluster-scoped
 permissions. It may be shown to users in the UI.
 
-
 #### type: STORAGE_CLASS
 
 All Storage Classes need to be defined as parameters in `schema.yaml`.


### PR DESCRIPTION
Update docs now that `cluster-admin` is now disallowed in `SERVICE_ACCOUNT`properties. Recommend that `deployerServiceAccount` is used when long-lived service accounts are not needed.

/gcbrun