### PR TITLE
Allow selection of storage class provisioner in mpdev

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -33,6 +33,7 @@ The manifests include the deployer-related resources.
 
 _DEFAULT_STORAGE_CLASS_PROVISIONER = 'kubernetes.io/gce-pd'
 
+
 def main():
   parser = ArgumentParser(description=_PROG_HELP)
   schema_values_common.add_to_argument_parser(parser)
@@ -59,7 +60,8 @@ def main():
 
 
 def process(schema, values, deployer_image, deployer_entrypoint, version_repo,
-            image_pull_secret, deployer_service_account_name, storage_class_provisioner):
+            image_pull_secret, deployer_service_account_name,
+            storage_class_provisioner):
   props = {}
   manifests = []
   app_name = get_name(schema, values)
@@ -96,7 +98,11 @@ def process(schema, values, deployer_image, deployer_entrypoint, version_repo,
       manifests += sa_manifests
     elif prop.storage_class:
       value, sc_manifests = provision_storage_class(
-          schema, prop, app_name=app_name, namespace=namespace, provisioner=storage_class_provisioner)
+          schema,
+          prop,
+          app_name=app_name,
+          namespace=namespace,
+          provisioner=storage_class_provisioner)
       props[prop.name] = value
       manifests += sc_manifests
     elif prop.xtype == config_helper.XTYPE_ISTIO_ENABLED:
@@ -666,13 +672,11 @@ def provision_storage_class(schema, prop, app_name, namespace, provisioner):
     provisioner = _DEFAULT_STORAGE_CLASS_PROVISIONER
 
   if provisioner == 'kubernetes.io/vsphere-volume':
-    parameters = {
-      'diskformat': 'thin'
-    }
+    parameters = {'diskformat': 'thin'}
   elif provisioner == 'kubernetes.io/gce-pd':
     if prop.storage_class.ssd:
       parameters = {
-        'type': 'pd-ssd',
+          'type': 'pd-ssd',
       }
     else:
       raise Exception('Do not know how to provision for property {}'.format(

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -505,8 +505,7 @@ class ProvisionTest(unittest.TestCase):
     storage_class_provisioner = None
     provision.process(schema, values, deployer_image, deployer_entrypoint,
                       version_repo, image_pull_secret,
-                      deployer_service_account_name,
-                      storage_class_provisioner)
+                      deployer_service_account_name, storage_class_provisioner)
 
   def test_process_schema_v1(self):
     schema = self.generate_schema_v1()
@@ -523,68 +522,64 @@ class ProvisionTest(unittest.TestCase):
   def test_provision_storage_class_vsphere(self):
     schema = self.generate_schema_v1()
     prop = config_helper.SchemaProperty(
-      "storageClass", 
-      {
-        "type": "string",
-        "x-google-marketplace": {
-          "type": "STORAGE_CLASS",
-          "storageClass": {
-            "type": "SSD"
-          },
-        }
-      },
-      True
-    )
-    manifest = provision.provision_storage_class(schema, prop, "app-1", "mynamespace", "kubernetes.io/vsphere-volume")
-    self.assertEqual(manifest, 
-      ('mynamespace-app-1-storageclass', 
-        [{
-          'apiVersion': 'storage.k8s.io/v1', 
-          'kind': 'StorageClass', 
-          'metadata': {
-            'name': 'mynamespace-app-1-storageclass', 
+        "storageClass", {
+            "type": "string",
+            "x-google-marketplace": {
+                "type": "STORAGE_CLASS",
+                "storageClass": {
+                    "type": "SSD"
+                },
+            }
+        }, True)
+    manifest = provision.provision_storage_class(
+        schema, prop, "app-1", "mynamespace", "kubernetes.io/vsphere-volume")
+    self.assertEqual(manifest, ('mynamespace-app-1-storageclass', [{
+        'apiVersion': 'storage.k8s.io/v1',
+        'kind': 'StorageClass',
+        'metadata': {
+            'name': 'mynamespace-app-1-storageclass',
             'labels': {
-              'app.kubernetes.io/component': 'auto-provisioned.marketplace.cloud.google.com', 
-              'marketplace.cloud.google.com/auto-provisioned-for-property': 'storageClass'
-              }
-          }, 
-          'provisioner': 'kubernetes.io/vsphere-volume', 
-          'parameters': {
+                'app.kubernetes.io/component':
+                    'auto-provisioned.marketplace.cloud.google.com',
+                'marketplace.cloud.google.com/auto-provisioned-for-property':
+                    'storageClass'
+            }
+        },
+        'provisioner': 'kubernetes.io/vsphere-volume',
+        'parameters': {
             'diskformat': 'thin'
-          }
-        }]))
+        }
+    }]))
 
   def test_provision_storage_class_gce_pd(self):
     schema = self.generate_schema_v1()
     prop = config_helper.SchemaProperty(
-      "storageClass", 
-      {
-        "type": "string",
-        "x-google-marketplace": {
-          "type": "STORAGE_CLASS",
-          "storageClass": {
-            "type": "SSD"
-          },
-        }
-      },
-      True
-    )
-    manifest = provision.provision_storage_class(schema, prop, "app-1", "mynamespace", "kubernetes.io/gce-pd")
-    self.assertEqual(manifest, 
-      ('mynamespace-app-1-storageclass', 
-        [{
-          'apiVersion': 'storage.k8s.io/v1', 
-          'kind': 'StorageClass', 
-          'metadata': {
-            'name': 'mynamespace-app-1-storageclass', 
+        "storageClass", {
+            "type": "string",
+            "x-google-marketplace": {
+                "type": "STORAGE_CLASS",
+                "storageClass": {
+                    "type": "SSD"
+                },
+            }
+        }, True)
+    manifest = provision.provision_storage_class(schema, prop, "app-1",
+                                                 "mynamespace",
+                                                 "kubernetes.io/gce-pd")
+    self.assertEqual(manifest, ('mynamespace-app-1-storageclass', [{
+        'apiVersion': 'storage.k8s.io/v1',
+        'kind': 'StorageClass',
+        'metadata': {
+            'name': 'mynamespace-app-1-storageclass',
             'labels': {
-              'app.kubernetes.io/component': 'auto-provisioned.marketplace.cloud.google.com', 
-              'marketplace.cloud.google.com/auto-provisioned-for-property': 'storageClass'
-              }
-          }, 
-          'provisioner': 'kubernetes.io/gce-pd', 
-          'parameters': {
+                'app.kubernetes.io/component':
+                    'auto-provisioned.marketplace.cloud.google.com',
+                'marketplace.cloud.google.com/auto-provisioned-for-property':
+                    'storageClass'
+            }
+        },
+        'provisioner': 'kubernetes.io/gce-pd',
+        'parameters': {
             'type': 'pd-ssd'
-          }
-        }]))
-
+        }
+    }]))

--- a/scripts/install
+++ b/scripts/install
@@ -39,6 +39,10 @@ case $i in
     image_pull_secret="${i#*=}"
     shift
     ;;
+  --storage_class_provisioner=*)
+    storage_class_provisioner="${i#*=}"
+    shift
+    ;;
   *)
     >&2 echo "Unrecognized flag: $i"
     exit 1
@@ -140,6 +144,7 @@ echo "${parameters}" \
     --deployer_service_account_name="${deployer_service_account_name}" \
     --version_repo="${version_repo}" \
     --image_pull_secret="${image_pull_secret}" \
+    --storage_class_provisioner="${storage_class_provisioner}" \
   | set_app_labels.py \
     --manifests=- \
     --dest=- \

--- a/scripts/verify
+++ b/scripts/verify
@@ -44,6 +44,10 @@ case $i in
     image_pull_secret="${i#*=}"
     shift
     ;;
+  --storage_class_provisioner=*)
+    storage_class_provisioner="${i#*=}"
+    shift
+    ;;
   *)
     echo "Unrecognized flag: $i"
     exit 1
@@ -97,14 +101,15 @@ function delete_namespace() {
 }
 
 function clean_resources() {
-  if [[ -z "$resources_cleaned" ]]; then
-    echo "INFO cleaning all resources."
-    delete_namespace
-    if [[ ! -z "$deployer_role_name" ]]; then
-      kubectl delete clusterrolebinding "$deployer_role_name"
-    fi
-    resources_cleaned="true"
-  fi
+  # if [[ -z "$resources_cleaned" ]]; then
+  #   echo "INFO cleaning all resources."
+  #   delete_namespace
+  #   if [[ ! -z "$deployer_role_name" ]]; then
+  #     kubectl delete clusterrolebinding "$deployer_role_name"
+  #   fi
+  #   resources_cleaned="true"
+  # fi
+  echo 'no clean'
 }
 
 function clean_and_exit() {
@@ -265,6 +270,7 @@ echo "INFO Initializes the deployer container which will deploy all the applicat
   --deployer="$deployer" \
   --parameters="$parameters" \
   --entrypoint='/bin/deploy_with_tests.sh' \
+  --storage_class_provisioner="$storage_class_provisioner" \
   || clean_and_exit "ERROR Failed to start deployer"
 
 echo "INFO wait for the deployer to succeed"
@@ -298,32 +304,32 @@ done
 kubectl logs "jobs/$deployer_name" --namespace="$NAMESPACE" || echo "ERROR Failed to get logs for deployer $deployer_name"
 deployer_name=""
 
-echo "INFO Stop the application"
-kubectl delete "application/$NAME" \
-    --namespace="$NAMESPACE" \
-  || clean_and_exit "ERROR Failed to stop application"
+# echo "INFO Stop the application"
+# kubectl delete "application/$NAME" \
+#     --namespace="$NAMESPACE" \
+#   || clean_and_exit "ERROR Failed to stop application"
 
-deletion_timeout=180
-echo "INFO Wait for the applications to be deleted"
-/scripts/wait_for_deletion.sh \
-  --namespace="$NAMESPACE" \
-  --kind=applications.app.k8s.io \
-  --timeout="$deletion_timeout" \
-  || clean_and_exit "ERROR Some applications were not deleted"
+# deletion_timeout=180
+# echo "INFO Wait for the applications to be deleted"
+# /scripts/wait_for_deletion.sh \
+#   --namespace="$NAMESPACE" \
+#   --kind=applications.app.k8s.io \
+#   --timeout="$deletion_timeout" \
+#   || clean_and_exit "ERROR Some applications were not deleted"
 
-echo "INFO Wait for standard resources were deleted."
-/scripts/wait_for_deletion.sh \
-  --namespace="$NAMESPACE" \
-  --kind=all \
-  --timeout="$deletion_timeout" \
-  || clean_and_exit "ERROR Some resources were not deleted"
+# echo "INFO Wait for standard resources were deleted."
+# /scripts/wait_for_deletion.sh \
+#   --namespace="$NAMESPACE" \
+#   --kind=all \
+#   --timeout="$deletion_timeout" \
+#   || clean_and_exit "ERROR Some resources were not deleted"
 
-echo "INFO Wait for service accounts to be deleted."
-/scripts/wait_for_deletion.sh \
-  --namespace="$NAMESPACE" \
-  --kind=serviceaccounts,roles,rolebindings \
-  --timeout="$deletion_timeout" \
-  || clean_and_exit "ERROR Some service accounts or roles were not deleted"
+# echo "INFO Wait for service accounts to be deleted."
+# /scripts/wait_for_deletion.sh \
+#   --namespace="$NAMESPACE" \
+#   --kind=serviceaccounts,roles,rolebindings \
+#   --timeout="$deletion_timeout" \
+#   || clean_and_exit "ERROR Some service accounts or roles were not deleted"
 
 trap - EXIT
 

--- a/scripts/verify
+++ b/scripts/verify
@@ -101,15 +101,14 @@ function delete_namespace() {
 }
 
 function clean_resources() {
-  # if [[ -z "$resources_cleaned" ]]; then
-  #   echo "INFO cleaning all resources."
-  #   delete_namespace
-  #   if [[ ! -z "$deployer_role_name" ]]; then
-  #     kubectl delete clusterrolebinding "$deployer_role_name"
-  #   fi
-  #   resources_cleaned="true"
-  # fi
-  echo 'no clean'
+  if [[ -z "$resources_cleaned" ]]; then
+    echo "INFO cleaning all resources."
+    delete_namespace
+    if [[ ! -z "$deployer_role_name" ]]; then
+      kubectl delete clusterrolebinding "$deployer_role_name"
+    fi
+    resources_cleaned="true"
+  fi
 }
 
 function clean_and_exit() {
@@ -304,32 +303,32 @@ done
 kubectl logs "jobs/$deployer_name" --namespace="$NAMESPACE" || echo "ERROR Failed to get logs for deployer $deployer_name"
 deployer_name=""
 
-# echo "INFO Stop the application"
-# kubectl delete "application/$NAME" \
-#     --namespace="$NAMESPACE" \
-#   || clean_and_exit "ERROR Failed to stop application"
+echo "INFO Stop the application"
+kubectl delete "application/$NAME" \
+    --namespace="$NAMESPACE" \
+  || clean_and_exit "ERROR Failed to stop application"
 
-# deletion_timeout=180
-# echo "INFO Wait for the applications to be deleted"
-# /scripts/wait_for_deletion.sh \
-#   --namespace="$NAMESPACE" \
-#   --kind=applications.app.k8s.io \
-#   --timeout="$deletion_timeout" \
-#   || clean_and_exit "ERROR Some applications were not deleted"
+deletion_timeout=180
+echo "INFO Wait for the applications to be deleted"
+/scripts/wait_for_deletion.sh \
+  --namespace="$NAMESPACE" \
+  --kind=applications.app.k8s.io \
+  --timeout="$deletion_timeout" \
+  || clean_and_exit "ERROR Some applications were not deleted"
 
-# echo "INFO Wait for standard resources were deleted."
-# /scripts/wait_for_deletion.sh \
-#   --namespace="$NAMESPACE" \
-#   --kind=all \
-#   --timeout="$deletion_timeout" \
-#   || clean_and_exit "ERROR Some resources were not deleted"
+echo "INFO Wait for standard resources were deleted."
+/scripts/wait_for_deletion.sh \
+  --namespace="$NAMESPACE" \
+  --kind=all \
+  --timeout="$deletion_timeout" \
+  || clean_and_exit "ERROR Some resources were not deleted"
 
-# echo "INFO Wait for service accounts to be deleted."
-# /scripts/wait_for_deletion.sh \
-#   --namespace="$NAMESPACE" \
-#   --kind=serviceaccounts,roles,rolebindings \
-#   --timeout="$deletion_timeout" \
-#   || clean_and_exit "ERROR Some service accounts or roles were not deleted"
+echo "INFO Wait for service accounts to be deleted."
+/scripts/wait_for_deletion.sh \
+  --namespace="$NAMESPACE" \
+  --kind=serviceaccounts,roles,rolebindings \
+  --timeout="$deletion_timeout" \
+  || clean_and_exit "ERROR Some service accounts or roles were not deleted"
 
 trap - EXIT
 


### PR DESCRIPTION
Introducing optional property storage_class_provisioner

Usage:
mpdev verify --deployer="$DEPLOYER" --wait_timeout="$WAIT_TIMEOUT" --image_pull_secret="$IMAGE_PULL_SECRET" --storage_class_provisioner=kubernetes.io/vsphere-volume

Supported values:
kubernetes.io/vsphere-volume
kubernetes.io/gce-pd

If no value is provided, kubernetes.io/gce-pd is used by default