### PR TITLE
Use WaitForFirstConsumer for GCP PersistentDisks

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -671,9 +671,11 @@ def provision_storage_class(schema, prop, app_name, namespace, provisioner):
   if not provisioner:
     provisioner = _DEFAULT_STORAGE_CLASS_PROVISIONER
 
+  volume_binding_mode = ''
   if provisioner == 'kubernetes.io/vsphere-volume':
     parameters = {'diskformat': 'thin'}
   elif provisioner == 'kubernetes.io/gce-pd':
+    volume_binding_mode = 'WaitForConsumer'
     if prop.storage_class.ssd:
       parameters = {
           'type': 'pd-ssd',
@@ -690,7 +692,8 @@ def provision_storage_class(schema, prop, app_name, namespace, provisioner):
           'name': sc_name,
       },
       'provisioner': provisioner,
-      'parameters': parameters
+      'parameters': parameters,
+      'volumeBindingMode': volume_binding_mode
   }]
   return sc_name, add_preprovisioned_labels(manifests, prop.name)
 

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -671,7 +671,7 @@ def provision_storage_class(schema, prop, app_name, namespace, provisioner):
   if not provisioner:
     provisioner = _DEFAULT_STORAGE_CLASS_PROVISIONER
 
-  volume_binding_mode = ''
+  volume_binding_mode = 'Immediate'
   if provisioner == 'kubernetes.io/vsphere-volume':
     parameters = {'diskformat': 'thin'}
   elif provisioner == 'kubernetes.io/gce-pd':

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -675,7 +675,7 @@ def provision_storage_class(schema, prop, app_name, namespace, provisioner):
   if provisioner == 'kubernetes.io/vsphere-volume':
     parameters = {'diskformat': 'thin'}
   elif provisioner == 'kubernetes.io/gce-pd':
-    volume_binding_mode = 'WaitForConsumer'
+    volume_binding_mode = 'WaitForFirstConsumer'
     if prop.storage_class.ssd:
       parameters = {
           'type': 'pd-ssd',

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -670,11 +670,12 @@ def provision_service_account(schema, prop, app_name, namespace,
 def provision_storage_class(schema, prop, app_name, namespace, provisioner):
   if not provisioner:
     provisioner = _DEFAULT_STORAGE_CLASS_PROVISIONER
-
   volume_binding_mode = 'Immediate'
   if provisioner == 'kubernetes.io/vsphere-volume':
     parameters = {'diskformat': 'thin'}
   elif provisioner == 'kubernetes.io/gce-pd':
+    # WaitForFirstConsumer is only available for gce-pd. See:
+    # https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
     volume_binding_mode = 'WaitForFirstConsumer'
     if prop.storage_class.ssd:
       parameters = {

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -581,5 +581,6 @@ class ProvisionTest(unittest.TestCase):
         'provisioner': 'kubernetes.io/gce-pd',
         'parameters': {
             'type': 'pd-ssd'
-        }
+        },
+        'volumeBindingMode': 'WaitForFirstConsumer'
     }]))

--- a/marketplace/deployer_util/provision_test.py
+++ b/marketplace/deployer_util/provision_test.py
@@ -548,7 +548,8 @@ class ProvisionTest(unittest.TestCase):
         'provisioner': 'kubernetes.io/vsphere-volume',
         'parameters': {
             'diskformat': 'thin'
-        }
+        },
+        'volumeBindingMode': 'Immediate'
     }]))
 
   def test_provision_storage_class_gce_pd(self):


### PR DESCRIPTION
Pods can be unscheduable due to a Volume Node Affinity Conflict. This can happen when a pod has multiple pvcs, but the persistent volumes were created in different zones and thus not all pvs could be attached.

Kubernetes documentation suggests using WaitForFirstConsumer to avoid these issues. https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode