### PR TITLE
Support kubernetes.io/no-provisioner

### DIFF
--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -685,6 +685,7 @@ def provision_storage_class(schema, prop, app_name, namespace, provisioner):
       raise Exception('Do not know how to provision for property {}'.format(
           prop.name))
   elif provisioner == 'kubernetes.io/no-provisioner':
+    # local-shared storage class is already pre-provisioned
     return 'local-shared', []
 
   sc_name = dns1123_name('{}-{}-{}'.format(namespace, app_name, prop.name))

--- a/marketplace/deployer_util/provision.py
+++ b/marketplace/deployer_util/provision.py
@@ -684,6 +684,8 @@ def provision_storage_class(schema, prop, app_name, namespace, provisioner):
     else:
       raise Exception('Do not know how to provision for property {}'.format(
           prop.name))
+  elif provisioner == 'kubernetes.io/no-provisioner':
+    return 'local-shared', []
 
   sc_name = dns1123_name('{}-{}-{}'.format(namespace, app_name, prop.name))
   manifests = [{


### PR DESCRIPTION
This is required to run verification in baremetal clusters, where there is no storage provisioner. More on storage provisioners at https://kubernetes.io/docs/concepts/storage/storage-classes/#local