### PR TITLE
Creating multiple log files for mpdev verify

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -162,6 +162,7 @@ steps:
   env:
   - 'KUBE_CONFIG=/workspace/.kube'
   - 'GCLOUD_CONFIG=/workspace/.config/gcloud'
+  - 'VERIFICATION_LOGS_PATH=/workspace/.mpdev_logs'
   # Use local Docker network named cloudbuild as described here:
   # https://cloud.google.com/cloud-build/docs/overview#build_configuration_and_build_steps
   - 'EXTRA_DOCKER_PARAMS=--net cloudbuild'

--- a/docs/mpdev-references.md
+++ b/docs/mpdev-references.md
@@ -123,18 +123,18 @@ values for verification.
 
 Logs from verify can be extensive, so they are separated in multiple files to facilitate troubleshooting
 
-- **resources.yaml:** Output of `kubectl get` for different kind of resources in the namespace. It should help visualize the footprint of the application after installation is complete.
+- `resources.yaml:` Output of `kubectl get` for different kind of resources in the namespace. It should help visualize the footprint of the application after installation is complete.
 
-- **resources_cleanup.yaml:** Output of `kubectl get` right before namespace deletion. At this point, the application should be uninstalled and all resources deleted, so the output is expected to be an empty list of resources in a normal verification. This helps identify resources not deleted when the application is uninstalled. It could also contain resources when verification fails before the uninstall step.
+- `resources_cleanup.yaml:` Output of `kubectl get` right before namespace deletion. At this point, the application should be uninstalled and all resources deleted, so the output is expected to be an empty list of resources in a normal verification. This helps identify resources not deleted when the application is uninstalled. It could also contain resources when verification fails before the uninstall step.
 
-- **tester.log:** Logs from the tester.
+- `tester.log:` Logs from the tester.
   - **Notice that** that old deployers might not have the changes necessary to generate this file. If it is empty, make sure you are using the latest deployer base image. Even in this case, tester logs will be found in the deployer logs.
 
-- **deployer.log:** Logs extracted from deployer. Deployer runs the tester container, so it also includes the tester logs.
+- `deployer.log:` Logs extracted from deployer. Deployer runs the tester container, so it also includes the tester logs.
 
-- **events.log:** contains all the namespace events collected before its deletion
+- `events.log:` contains all the namespace events collected before its deletion
 
-- **verify.log:** The entire output. It includes the events, deployer logs, tester logs and resources_cleanup.yaml. It does not include resources application resources, since this tends to be more verbose.
+- `verify.log:` The entire output. It includes the events, deployer logs, tester logs and resources_cleanup.yaml. It does not include resources application resources, since this tends to be more verbose.
 
 ### Setting verify script timeouts
 

--- a/docs/mpdev-references.md
+++ b/docs/mpdev-references.md
@@ -119,6 +119,23 @@ Properties in `/data-test/schema.yaml` will override properties in
 `/data/schema.yaml`. This can also be used to overwrite existing default
 values for verification.
 
+#### Verification logs
+
+Logs from verify can be extensive, so they are separated in multiple files to facilitate troubleshooting
+
+- **resources.yaml:** Output of `kubectl get` for different kind of resources in the namespace. It should help visualize the footprint of the application after installation is complete.
+
+- **resources_cleanup.yaml:** Output of `kubectl get` right before namespace deletion. At this point, the application should be uninstalled and all resources deleted, so the output is expected to be an empty list of resources in a normal verification. This helps identify resources not deleted when the application is uninstalled. It could also contain resources when verification fails before the uninstall step.
+
+- **tester.log:** Logs from the tester.
+  - **Notice that** that old deployers might not have the changes necessary to generate this file. If it is empty, make sure you are using the latest deployer base image. Even in this case, tester logs will be found in the deployer logs.
+
+- **deployer.log:** Logs extracted from deployer. Deployer runs the tester container, so it also includes the tester logs.
+
+- **events.log:** contains all the namespace events collected before its deletion
+
+- **verify.log:** The entire output. It includes the events, deployer logs, tester logs and resources_cleanup.yaml. It does not include resources application resources, since this tends to be more verbose.
+
 ### Setting verify script timeouts
 
 The `verify` command can have its duration until timeout value set by using

--- a/marketplace/deployer_helm_base/create_manifests.sh
+++ b/marketplace/deployer_helm_base/create_manifests.sh
@@ -74,7 +74,7 @@ if [[ "$mode" = "test" ]]; then
 
   overlay_test_files.py \
     --manifest "$data_dir/extracted" \
-    --test_manifest "$test_data_dir/extracted"
+    --test_manifest "$test_data_dir/extracted" | awk '{print "SMOKE_TEST "$0}'
 fi
 
 # Log information and, at the same time, catch errors early and separately.

--- a/marketplace/deployer_helm_base/create_manifests.sh
+++ b/marketplace/deployer_helm_base/create_manifests.sh
@@ -74,7 +74,8 @@ if [[ "$mode" = "test" ]]; then
 
   overlay_test_files.py \
     --manifest "$data_dir/extracted" \
-    --test_manifest "$test_data_dir/extracted" | awk '{print "SMOKE_TEST "$0}'
+    --test_manifest "$test_data_dir/extracted" \
+    | awk '{print "SMOKE_TEST "$0}'
 fi
 
 # Log information and, at the same time, catch errors early and separately.

--- a/marketplace/deployer_util/constants.py
+++ b/marketplace/deployer_util/constants.py
@@ -13,5 +13,3 @@
 # limitations under the License.
 
 GOOGLE_CLOUD_TEST = 'marketplace.cloud.google.com/verification'
-
-LOG_SMOKE_TEST = 'SMOKE_TEST'

--- a/marketplace/deployer_util/deploy_with_tests.sh
+++ b/marketplace/deployer_util/deploy_with_tests.sh
@@ -43,7 +43,8 @@ test_schema="/data-test/schema.yaml"
 overlay_test_schema.py \
   --test_schema "$test_schema" \
   --original_schema "/data/schema.yaml" \
-  --output "/data/schema.yaml" | awk '{print "SMOKE_TEST "$0}'
+  --output "/data/schema.yaml" \
+  | awk '{print "SMOKE_TEST "$0}'
 
 NAME="$(/bin/print_config.py \
     --xtype NAME \
@@ -106,7 +107,8 @@ if [[ -e "$tester_manifest" ]]; then
   run_tester.py \
     --namespace $NAMESPACE \
     --manifest $tester_manifest \
-    --timeout ${TESTER_TIMEOUT:-300} | awk '{print "SMOKE_TEST "$0}'
+    --timeout ${TESTER_TIMEOUT:-300} \
+    | awk '{print "SMOKE_TEST "$0}'
 else
   echo "SMOKE_TEST No tester manifest found at $tester_manifest."
 fi

--- a/marketplace/deployer_util/deploy_with_tests.sh
+++ b/marketplace/deployer_util/deploy_with_tests.sh
@@ -39,12 +39,11 @@ handle_failure() {
 }
 trap "handle_failure" EXIT
 
-LOG_SMOKE_TEST="SMOKE_TEST"
 test_schema="/data-test/schema.yaml"
 overlay_test_schema.py \
   --test_schema "$test_schema" \
   --original_schema "/data/schema.yaml" \
-  --output "/data/schema.yaml"
+  --output "/data/schema.yaml" | awk '{print "SMOKE_TEST "$0}'
 
 NAME="$(/bin/print_config.py \
     --xtype NAME \
@@ -107,9 +106,9 @@ if [[ -e "$tester_manifest" ]]; then
   run_tester.py \
     --namespace $NAMESPACE \
     --manifest $tester_manifest \
-    --timeout ${TESTER_TIMEOUT:-300}
+    --timeout ${TESTER_TIMEOUT:-300} | awk '{print "SMOKE_TEST "$0}'
 else
-  echo "$LOG_SMOKE_TEST No tester manifest found at $tester_manifest."
+  echo "SMOKE_TEST No tester manifest found at $tester_manifest."
 fi
 
 clean_iam_resources.sh

--- a/marketplace/deployer_util/overlay_test_schema.py
+++ b/marketplace/deployer_util/overlay_test_schema.py
@@ -19,7 +19,6 @@ import os.path
 from argparse import ArgumentParser
 
 import log_util as log
-from constants import LOG_SMOKE_TEST
 from dict_util import deep_get
 from yaml_util import load_yaml
 

--- a/marketplace/deployer_util/overlay_test_schema.py
+++ b/marketplace/deployer_util/overlay_test_schema.py
@@ -45,8 +45,8 @@ def main():
     test_schema = load_yaml(args.test_schema)
   else:
     log.info(
-        '{} Test schema file {} does not exist. '
-        'Using the original schema.', LOG_SMOKE_TEST, args.test_schema)
+        'Test schema file {} does not exist. '
+        'Using the original schema.', args.test_schema)
     test_schema = {}
 
   output_schema = load_yaml(args.original_schema)

--- a/marketplace/deployer_util/run_tester.py
+++ b/marketplace/deployer_util/run_tester.py
@@ -43,8 +43,7 @@ def main():
         '''.format(args.namespace, args.manifest),
         print_call=True)
   except CommandException as ex:
-    log.error("Failed to apply tester job. Reason: {}",
-              ex.message)
+    log.error("Failed to apply tester job. Reason: {}", ex.message)
     return
 
   resources = load_resources_yaml(args.manifest)

--- a/marketplace/deployer_util/run_tester.py
+++ b/marketplace/deployer_util/run_tester.py
@@ -21,7 +21,6 @@ import log_util as log
 from argparse import ArgumentParser
 from bash_util import Command
 from bash_util import CommandException
-from constants import LOG_SMOKE_TEST
 from dict_util import deep_get
 from yaml_util import load_resources_yaml
 
@@ -44,7 +43,7 @@ def main():
         '''.format(args.namespace, args.manifest),
         print_call=True)
   except CommandException as ex:
-    log.error("{} Failed to apply tester job. Reason: {}", LOG_SMOKE_TEST,
+    log.error("Failed to apply tester job. Reason: {}",
               ex.message)
     return
 
@@ -82,18 +81,18 @@ def main():
 
       if result == "Failed":
         print_tester_logs(full_name, args.namespace)
-        log.error("{} Tester '{}' failed.", LOG_SMOKE_TEST, full_name)
+        log.error("Tester '{}' failed.", full_name)
         test_failed = True
         break
 
       if result == "Succeeded":
         print_tester_logs(full_name, args.namespace)
-        log.info("{} Tester '{}' succeeded.", LOG_SMOKE_TEST, full_name)
+        log.info("Tester '{}' succeeded.", full_name)
         break
 
       if time.time() - start_time > tester_timeout:
         print_tester_logs(full_name, args.namespace)
-        log.error("{} Tester '{}' timeout.", LOG_SMOKE_TEST, full_name)
+        log.error("Tester '{}' timeout.", full_name)
         test_failed = True
         break
 
@@ -111,7 +110,7 @@ def print_tester_logs(full_name, namespace):
         print_result=True)
   except CommandException as ex:
     log.error(str(ex))
-    log.error("{} failed to get the tester logs.", LOG_SMOKE_TEST)
+    log.error("Failed to get the tester logs.")
 
 
 if __name__ == "__main__":

--- a/scripts/dev
+++ b/scripts/dev
@@ -9,6 +9,7 @@ GCLOUD_CONFIG=${GCLOUD_CONFIG:-$HOME/.config/gcloud}
 EXTRA_DOCKER_PARAMS=${EXTRA_DOCKER_PARAMS:-}
 MARKETPLACE_TOOLS_TAG=${MARKETPLACE_TOOLS_TAG:-latest}
 MARKETPLACE_TOOLS_IMAGE=${MARKETPLACE_TOOLS_IMAGE:-gcr.io/cloud-marketplace-tools/k8s/dev}
+VERIFICATION_LOGS_PATH=${VERIFICATION_LOGS_PATH:-$HOME/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')}
 
 kube_mount=""
 if [[ -f "${KUBE_CONFIG}" ]]; then
@@ -39,13 +40,12 @@ if [[ -t 0 ]]; then
   terminal_docker_param="-it"
 fi
 
-logdir="$HOME/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')"
-mkdir -p "$logdir"
-echo "Logs stored in $logdir" | tee "$logdir/verify.log"
+mkdir -p "$VERIFICATION_LOGS_PATH"
+echo "Logs stored in $VERIFICATION_LOGS_PATH" | tee "$VERIFICATION_LOGS_PATH/verify.log"
 
 docker run \
   --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,readonly" \
-  --mount "type=bind,source=$logdir,target=/logs" \
+  --mount "type=bind,source=$VERIFICATION_LOGS_PATH,target=/logs" \
   --net=host \
   ${kube_mount[*]} \
   ${gcloud_mount[*]} \
@@ -53,4 +53,4 @@ docker run \
   ${EXTRA_DOCKER_PARAMS[*]} \
   "${terminal_docker_param}" --rm \
   "${MARKETPLACE_TOOLS_IMAGE}:${MARKETPLACE_TOOLS_TAG}" \
-  "$@" 2>&1 | tee "$logdir/verify.log"
+  "$@" 2>&1 | tee "$VERIFICATION_LOGS_PATH/verify.log"

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 # KUBE_CONFIG can point to a kubeconfig file or
 # the standard kubectl config directory.

--- a/scripts/dev
+++ b/scripts/dev
@@ -39,7 +39,7 @@ if [[ -t 0 ]]; then
   terminal_docker_param="-it"
 fi
 
-logdir="/usr/local/google/home/ruela/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')"
+logdir="$HOME/ruela/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')"
 mkdir -p "$logdir"
 echo "Logs stored in $logdir" | tee "$logdir/verify.log"
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -39,7 +39,7 @@ if [[ -t 0 ]]; then
   terminal_docker_param="-it"
 fi
 
-logdir="$HOME/ruela/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')"
+logdir="$HOME/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')"
 mkdir -p "$logdir"
 echo "Logs stored in $logdir" | tee "$logdir/verify.log"
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -39,8 +39,13 @@ if [[ -t 0 ]]; then
   terminal_docker_param="-it"
 fi
 
+logdir="/usr/local/google/home/ruela/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')"
+mkdir -p "$logdir"
+echo "Logs stored in $logdir" | tee "$logdir/verify.log"
+
 docker run \
   --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,readonly" \
+  --mount "type=bind,source=$logdir,target=/logs" \
   --net=host \
   ${kube_mount[*]} \
   ${gcloud_mount[*]} \
@@ -48,4 +53,4 @@ docker run \
   ${EXTRA_DOCKER_PARAMS[*]} \
   "${terminal_docker_param}" --rm \
   "${MARKETPLACE_TOOLS_IMAGE}:${MARKETPLACE_TOOLS_TAG}" \
-  "$@"
+  "$@" 2>&1 | tee "$logdir/verify.log"

--- a/scripts/verify
+++ b/scripts/verify
@@ -308,6 +308,13 @@ cat "/logs/deployer.log" | grep '^SMOKE_TEST' > "/logs/tester.log" || echo "Fail
 
 deployer_name=""
 
+resources_yaml="/logs/resources.yaml"
+kubectl get applications.app.k8s.io --namespace "$NAMESPACE" --output=yaml > "$resources_yaml"
+echo "---" >> "$resources_yaml"
+kubectl get all --namespace "$NAMESPACE" --output=yaml >> "$resources_yaml"
+echo "---" >> "$resources_yaml"
+kubectl get serviceaccounts,roles,rolebindings --namespace "$NAMESPACE" --output=yaml >> "$resources_yaml"
+
 echo "INFO Stop the application"
 kubectl delete "application/$NAME" \
     --namespace="$NAMESPACE" \
@@ -315,7 +322,6 @@ kubectl delete "application/$NAME" \
 
 deletion_timeout="$wait_timeout"
 
-kubectl get applications.app.k8s.io --namespace "$NAMESPACE" --output=yaml >> "/logs/resources.yaml"
 echo "INFO Wait for the applications to be deleted"
 /scripts/wait_for_deletion.sh \
   --namespace="$NAMESPACE" \
@@ -323,7 +329,6 @@ echo "INFO Wait for the applications to be deleted"
   --timeout="$deletion_timeout" \
   || clean_and_exit "ERROR Some applications were not deleted"
 
-kubectl get all --namespace "$NAMESPACE" --output=yaml >> "/logs/resources.yaml"
 echo "INFO Wait for standard resources were deleted."
 /scripts/wait_for_deletion.sh \
   --namespace="$NAMESPACE" \
@@ -331,7 +336,6 @@ echo "INFO Wait for standard resources were deleted."
   --timeout="$deletion_timeout" \
   || clean_and_exit "ERROR Some resources were not deleted"
 
-kubectl get serviceaccounts,roles,rolebindings --namespace "$NAMESPACE" --output=yaml >> "/logs/resources.yaml"
 echo "INFO Wait for service accounts to be deleted."
 /scripts/wait_for_deletion.sh \
   --namespace="$NAMESPACE" \

--- a/scripts/verify
+++ b/scripts/verify
@@ -95,7 +95,8 @@ function delete_namespace() {
     delete_apiservices
     
     echo "INFO Deleting namespace \"$NAMESPACE\""
-    kubectl get all --namespace "$NAMESPACE" --output=yaml > "/logs/resources.yaml"
+    kubectl get all --namespace "$NAMESPACE" --output=yaml > "/logs/resources_cleanup.yaml"
+    cat "/logs/resources_cleanup.yaml"
     kubectl delete namespace "$NAMESPACE"
     namespace_deleted="true"
   fi
@@ -313,6 +314,8 @@ kubectl delete "application/$NAME" \
   || clean_and_exit "ERROR Failed to stop application"
 
 deletion_timeout="$wait_timeout"
+
+kubectl get applications.app.k8s.io --namespace "$NAMESPACE" --output=yaml >> "/logs/resources.yaml"
 echo "INFO Wait for the applications to be deleted"
 /scripts/wait_for_deletion.sh \
   --namespace="$NAMESPACE" \
@@ -320,6 +323,7 @@ echo "INFO Wait for the applications to be deleted"
   --timeout="$deletion_timeout" \
   || clean_and_exit "ERROR Some applications were not deleted"
 
+kubectl get all --namespace "$NAMESPACE" --output=yaml >> "/logs/resources.yaml"
 echo "INFO Wait for standard resources were deleted."
 /scripts/wait_for_deletion.sh \
   --namespace="$NAMESPACE" \
@@ -327,6 +331,7 @@ echo "INFO Wait for standard resources were deleted."
   --timeout="$deletion_timeout" \
   || clean_and_exit "ERROR Some resources were not deleted"
 
+kubectl get serviceaccounts,roles,rolebindings --namespace "$NAMESPACE" --output=yaml >> "/logs/resources.yaml"
 echo "INFO Wait for service accounts to be deleted."
 /scripts/wait_for_deletion.sh \
   --namespace="$NAMESPACE" \

--- a/scripts/verify
+++ b/scripts/verify
@@ -303,7 +303,7 @@ done
 # Get the logs from the deployer before deleting the application. Set deployer name to empty so clean up doesn't try to get its logs again.
 (kubectl logs "jobs/$deployer_name" --namespace="$NAMESPACE" --tail 9999 || echo "ERROR Failed to get logs for deployer $deployer_name") > "/logs/deployer.log"
 cat "/logs/deployer.log" | awk '{print "DEPLOYER "$0}'
-cat "/logs/deployer.log" | grep '^SMOKE_TEST' > "/logs/tester.log"
+cat "/logs/deployer.log" | grep '^SMOKE_TEST' > "/logs/tester.log" || echo "Failed to find tester logs"
 
 deployer_name=""
 

--- a/scripts/verify
+++ b/scripts/verify
@@ -59,7 +59,7 @@ done
 [[ -z "$parameters" ]] && parameters="{}"
 [[ -z "$wait_timeout" ]] && wait_timeout=600
 
-error_summary_path="$(mktemp)"
+error_summary_path="/logs/errors_summary.log"
 
 function delete_apiservices() {
   # Remove apiservices that are unavailable or attached to $NAMESPACE
@@ -80,21 +80,22 @@ function delete_apiservices() {
 function delete_namespace() {
   if [[ -z "$namespace_deleted" ]]; then
     echo "INFO Collecting events for namespace \"$NAMESPACE\""
-    kubectl get events --namespace="$NAMESPACE" || echo "ERROR Failed to get events for namespace \"$NAMESPACE\""
+    kubectl get events --namespace="$NAMESPACE" | tee "/logs/events.log" || echo "ERROR Failed to get events for namespace \"$NAMESPACE\""
+    cat "/logs/events.log"
     error_events="$(kubectl get events --namespace="$NAMESPACE" --field-selector="type!=Normal" || echo "ERROR Failed to get events for namespace \"$NAMESPACE\"")"
 
     if [[ ! -z $deployer_name ]]; then
       echo "INFO Collecting logs for deployer"
-      deployer_logs="$(kubectl logs "jobs/$deployer_name" --namespace="$NAMESPACE" --tail 9999 || echo "ERROR Failed to get logs for deployer $deployer_name")"
-      echo "$deployer_logs"
+      (kubectl logs "jobs/$deployer_name" --namespace="$NAMESPACE" --tail 9999 || echo "ERROR Failed to get logs for deployer $deployer_name") > "/logs/deployer.log"
+      cat "/logs/deployer.log" | awk '{print "DEPLOYER "$0}'
 
-      deployer_errors="$(echo "$deployer_logs" | /scripts/filter_deployer_logs.py)"
+      deployer_errors="$(cat "/logs/deployer.log" | /scripts/filter_deployer_logs.py)"
     fi
 
     delete_apiservices
     
     echo "INFO Deleting namespace \"$NAMESPACE\""
-    kubectl get all --namespace "$NAMESPACE" --output=yaml
+    kubectl get all --namespace "$NAMESPACE" --output=yaml > "/logs/resources.yaml"
     kubectl delete namespace "$NAMESPACE"
     namespace_deleted="true"
   fi
@@ -300,7 +301,10 @@ while true; do
 done
 
 # Get the logs from the deployer before deleting the application. Set deployer name to empty so clean up doesn't try to get its logs again.
-kubectl logs "jobs/$deployer_name" --namespace="$NAMESPACE" || echo "ERROR Failed to get logs for deployer $deployer_name"
+(kubectl logs "jobs/$deployer_name" --namespace="$NAMESPACE" --tail 9999 || echo "ERROR Failed to get logs for deployer $deployer_name") > "/logs/deployer.log"
+cat "/logs/deployer.log" | awk '{print "DEPLOYER "$0}'
+cat "/logs/deployer.log" | grep '^SMOKE_TEST' > "/logs/tester.log"
+
 deployer_name=""
 
 echo "INFO Stop the application"


### PR DESCRIPTION
Output from verify is very big and hard to consume. This change try to make troubleshooting easier by separating different sessions of the output in multiple files:

verify.log
The entire output. It includes the deployer logs

deployer.log
Only the log from deployer. It includes the tester logs.

tester.log
Only logs from the tester.

events.log
All the events collected before deleting the namespace

resources.yaml
All the resources that were applied. This session is huge and not often useful, so it is now removed from the output.