### PR TITLE
Upgrade kubectl and helm versions and change base image to Ubuntu 20.04

### DIFF
--- a/cloudbuild-tag-prerelease.yaml
+++ b/cloudbuild-tag-prerelease.yaml
@@ -39,7 +39,6 @@ steps:
   - -ceux
   - |
     mkdir charts-tgz/
-    helm init --client-only
     helm package marketplace/charts/marketplace-integration/ \
         --version $TAG_NAME \
         --destination charts-tgz/

--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -76,7 +76,6 @@ steps:
   - -ceux
   - |
     mkdir charts-tgz/
-    helm init --client-only
     helm package marketplace/charts/marketplace-integration/ \
         --version $TAG_NAME \
         --destination charts-tgz/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -162,6 +162,9 @@ steps:
   - 'KUBE_CONFIG=/workspace/.kube'
   - 'GCLOUD_CONFIG=/workspace/.config/gcloud'
   - 'VERIFICATION_LOGS_PATH=/workspace/.mpdev_logs'
+  # Use local Docker network named cloudbuild as described here:
+  # https://cloud.google.com/cloud-build/docs/overview#build_configuration_and_build_steps
+  - 'DOCKER_NETWORK_OVERRIDE=cloudbuild'
   - MARKETPLACE_TOOLS_TAG=testing-sha_$COMMIT_SHA
   args:
   - make

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -162,6 +162,9 @@ steps:
   - 'KUBE_CONFIG=/workspace/.kube'
   - 'GCLOUD_CONFIG=/workspace/.config/gcloud'
   - 'VERIFICATION_LOGS_PATH=/workspace/.mpdev_logs'
+  # Use local Docker network named cloudbuild as described here:
+  # https://cloud.google.com/cloud-build/docs/overview#build_configuration_and_build_steps
+  - 'EXTRA_DOCKER_PARAMS=--net cloudbuild'
   - MARKETPLACE_TOOLS_TAG=testing-sha_$COMMIT_SHA
   args:
   - make

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -164,7 +164,7 @@ steps:
   - 'VERIFICATION_LOGS_PATH=/workspace/.mpdev_logs'
   # Use local Docker network named cloudbuild as described here:
   # https://cloud.google.com/cloud-build/docs/overview#build_configuration_and_build_steps
-  - 'DOCKER_NETWORK_OVERRIDE=cloudbuild'
+  - 'DOCKER_NETWORK=cloudbuild'
   - MARKETPLACE_TOOLS_TAG=testing-sha_$COMMIT_SHA
   args:
   - make

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -165,7 +165,7 @@ steps:
   - MARKETPLACE_TOOLS_TAG=testing-sha_$COMMIT_SHA
   args:
   - make
-  - -j1
+  - -j10
   - --output-sync
   - tests/integration
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -124,7 +124,6 @@ steps:
   - -exc
   - |
     mkdir charts-tgz/
-    helm init --client-only
     helm package marketplace/charts/marketplace-integration/ \
         --version "0.0.0+sha.$COMMIT_SHA" \
         --destination charts-tgz/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -168,7 +168,7 @@ steps:
   - MARKETPLACE_TOOLS_TAG=testing-sha_$COMMIT_SHA
   args:
   - make
-  - -j10
+  - -j1
   - --output-sync
   - tests/integration
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -162,9 +162,6 @@ steps:
   - 'KUBE_CONFIG=/workspace/.kube'
   - 'GCLOUD_CONFIG=/workspace/.config/gcloud'
   - 'VERIFICATION_LOGS_PATH=/workspace/.mpdev_logs'
-  # Use local Docker network named cloudbuild as described here:
-  # https://cloud.google.com/cloud-build/docs/overview#build_configuration_and_build_steps
-  - 'EXTRA_DOCKER_PARAMS=--net cloudbuild'
   - MARKETPLACE_TOOLS_TAG=testing-sha_$COMMIT_SHA
   args:
   - make

--- a/marketplace/charts/marketplace-integration/Chart.yaml
+++ b/marketplace/charts/marketplace-integration/Chart.yaml
@@ -8,3 +8,4 @@ maintainers:
 - email: cloud-marketplace-tools@google.com
   name: Marketplace Tools
 name: marketplace-integration
+version: 0.0.0

--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/python
+FROM marketplace.gcr.io/google/debian11
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gettext \
     jq \
     wget \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \

--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -14,7 +14,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.20.12 1.21.6 1.22.3;  \
+RUN for full_version in 1.21.13 1.22.10 1.23.7 1.24.1;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \
@@ -22,7 +22,7 @@ RUN for full_version in 1.20.12 1.21.6 1.22.3;  \
             https://storage.googleapis.com/kubernetes-release/release/v$full_version/bin/linux/amd64/kubectl \
         && chmod 755 /opt/kubectl/$version/kubectl; \
      done;
-RUN ln -s /opt/kubectl/1.20 /opt/kubectl/default
+RUN ln -s /opt/kubectl/1.22 /opt/kubectl/default
 
 COPY marketplace/deployer_envsubst_base/* /bin/
 COPY marketplace/deployer_util/* /bin/

--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/debian11
+FROM marketplace.gcr.io/google/ubuntu2004
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \

--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.21.13 1.22.10 1.23.7 1.24.1;  \
+RUN for full_version in 1.21.11 1.22.8 1.23.5;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \

--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     python3 \
     python3-pip \
+    python-is-python3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \

--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     wget \
     python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/python
+FROM marketplace.gcr.io/google/debian11
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gettext \
     jq \
     wget \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -14,7 +14,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.20.12 1.21.6 1.22.3;  \
+RUN for full_version in 1.21.13 1.22.10 1.23.7 1.24.1;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \
@@ -22,11 +22,11 @@ RUN for full_version in 1.20.12 1.21.6 1.22.3;  \
             https://storage.googleapis.com/kubernetes-release/release/v$full_version/bin/linux/amd64/kubectl \
         && chmod 755 /opt/kubectl/$version/kubectl; \
      done;
-RUN ln -s /opt/kubectl/1.20 /opt/kubectl/default
+RUN ln -s /opt/kubectl/1.22 /opt/kubectl/default
 
 RUN mkdir -p /bin/helm-downloaded \
     && wget -q -O /bin/helm-downloaded/helm.tar.gz \
-        https://get.helm.sh/helm-v3.7.1-linux-amd64.tar.gz \
+        https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz \
     && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
     && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
     && rm -rf /bin/helm-downloaded

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/debian11
+FROM marketplace.gcr.io/google/ubuntu2004
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.21.13 1.22.10 1.23.7 1.24.1;  \
+RUN for full_version in 1.21.11 1.22.8 1.23.5;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     python3 \
     python3-pip \
+    python-is-python3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     wget \
     python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \

--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gnupg \
         python3 \
         python3-pip \
+        python-is-python3 \
      && rm -rf /var/lib/apt/lists/*
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \

--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -46,8 +46,7 @@ RUN mkdir -p /bin/helm-downloaded \
         https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz \
      && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
      && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
-     && rm -rf /bin/helm-downloaded \
-     && helm init --client-only
+     && rm -rf /bin/helm-downloaded
 
 RUN gcloud auth configure-docker
 

--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -1,9 +1,4 @@
-FROM marketplace.gcr.io/google/python
-
-# Add the Cloud SDK distribution URI as a package source
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-# Import the Google Cloud Platform public key
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+FROM marketplace.gcr.io/google/ubuntu2004
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -11,13 +6,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         gettext \
-        google-cloud-sdk \
-	google-cloud-sdk-gke-gcloud-auth-plugin \
         jq \
         make \
         software-properties-common \
         wget \
+        gnupg \
+        python3 \
+        python3-pip \
      && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+     && apt-get -y update \
+     && apt-get install -y google-cloud-sdk google-cloud-sdk-gke-gcloud-auth-plugin
 
 RUN pip3 install \
       wheel \
@@ -25,7 +26,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.13.12 1.14.8 1.15.11 1.16.9 1.17.5 1.18.2;  \
+RUN for full_version in 1.21.11 1.22.8 1.23.5;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \
@@ -33,20 +34,16 @@ RUN for full_version in 1.13.12 1.14.8 1.15.11 1.16.9 1.17.5 1.18.2;  \
             https://storage.googleapis.com/kubernetes-release/release/v$full_version/bin/linux/amd64/kubectl \
         && chmod 755 /opt/kubectl/$version/kubectl; \
      done;
-RUN ln -s /opt/kubectl/1.16 /opt/kubectl/default
+RUN ln -s /opt/kubectl/1.22 /opt/kubectl/default
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    apt-key fingerprint 0EBFCD88 && \
-    add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-       xenial \
-       edge" && \
-    apt-get -y update && \
-    apt-get -y install docker-ce=17.12.0~ce-0~ubuntu
+RUN echo "deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu focal edge" | tee /etc/apt/sources.list.d/docker.list \
+     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key --keyring /usr/share/keyrings/docker.gpg add - \
+     && apt-get -y update \
+     && apt-get -y install docker-ce=5:19.03.13~3-0~ubuntu-focal
 
 RUN mkdir -p /bin/helm-downloaded \
      && wget -q -O /bin/helm-downloaded/helm.tar.gz \
-        https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz \
+        https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz \
      && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
      && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
      && rm -rf /bin/helm-downloaded \

--- a/scripts/dev
+++ b/scripts/dev
@@ -7,6 +7,7 @@ set -euox pipefail
 KUBE_CONFIG=${KUBE_CONFIG:-$HOME/.kube/config}
 GCLOUD_CONFIG=${GCLOUD_CONFIG:-$HOME/.config/gcloud}
 EXTRA_DOCKER_PARAMS=${EXTRA_DOCKER_PARAMS:-}
+DOCKER_NETWORK=${DOCKER_NETWORK:-host}
 MARKETPLACE_TOOLS_TAG=${MARKETPLACE_TOOLS_TAG:-latest}
 MARKETPLACE_TOOLS_IMAGE=${MARKETPLACE_TOOLS_IMAGE:-gcr.io/cloud-marketplace-tools/k8s/dev}
 VERIFICATION_LOGS_PATH=${VERIFICATION_LOGS_PATH:-$HOME/.mpdev_logs/$(date '+%Y%m%d-%H%M%S')}
@@ -46,7 +47,7 @@ echo "Logs stored in $VERIFICATION_LOGS_PATH" | tee "$VERIFICATION_LOGS_PATH/ver
 docker run \
   --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,readonly" \
   --mount "type=bind,source=$VERIFICATION_LOGS_PATH,target=/logs" \
-  --net=${DOCKER_NETWORK_OVERRIDE:-host} \
+  --net=${DOCKER_NETWORK} \
   ${kube_mount[*]} \
   ${gcloud_mount[*]} \
   ${gcloud_original_path[*]} \

--- a/scripts/dev
+++ b/scripts/dev
@@ -46,7 +46,7 @@ echo "Logs stored in $VERIFICATION_LOGS_PATH" | tee "$VERIFICATION_LOGS_PATH/ver
 docker run \
   --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,readonly" \
   --mount "type=bind,source=$VERIFICATION_LOGS_PATH,target=/logs" \
-  --net=host \
+  --net=${DOCKER_NETWORK_OVERRIDE:-host} \
   ${kube_mount[*]} \
   ${gcloud_mount[*]} \
   ${gcloud_original_path[*]} \


### PR DESCRIPTION
* Upgrade kubectl to [current GKE versions](https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions) (1.21.11, 1.22.8, 1.23.5).
* Upgrade helm to 3.8.2.
* Use marketplace.gcr.io/google/ubuntu2004 as base images: using Ubuntu 20.04 will probably have better compatibility with the old google/python image (which is based on ubuntu 16.04), and is less likely break downstream images. Also, CVE-2015-20107 is marked as Low Severity on Ubuntu 20.04 by GCR Vulnerability Scanning, whereas on Debian 11 it is marked as Critical.
* Use a new `DOCKER_NETWORK` env var to override the Docker network in the `dev` script (default value is `host`; test script overrides it with `cloudbuild`): with the current way of using `EXTRA_DOCKER_PARAMS`, we get an error `docker: conflicting options: cannot attach both user-defined and non-user-defined network-modes`.
* Add `version: 0.0.0` to marketplace/charts/marketplace-integration/Chart.yaml: helm now validates the YAML before applying any command line overrides; see https://github.com/helm/helm/issues/9298#issuecomment-850568389.
