### PR TITLE
Ensure the /logs directory exists

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -59,6 +59,8 @@ done
 [[ -z "$parameters" ]] && parameters="{}"
 [[ -z "$wait_timeout" ]] && wait_timeout=600
 
+# Ensure /logs dir exists in case this script was run outside of scripts/dev
+mkdir -p "/logs"
 error_summary_path="/logs/errors_summary.log"
 
 function delete_apiservices() {


### PR DESCRIPTION
Needed to make executions of `scripts/verify` work outside of the context of `scripts/dev`. Has no effect if there is already a `/logs` directory.

/gcbrun