### PR TITLE
Fix SIGINT handling

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -45,6 +45,7 @@ mkdir -p "$VERIFICATION_LOGS_PATH"
 echo "Logs stored in $VERIFICATION_LOGS_PATH" | tee "$VERIFICATION_LOGS_PATH/verify.log"
 
 docker run \
+  --init \
   --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,readonly" \
   --mount "type=bind,source=$VERIFICATION_LOGS_PATH,target=/logs" \
   --net=${DOCKER_NETWORK} \


### PR DESCRIPTION
mpdev verify can sometimes only be killed via pkill -9 -f verify as ctrl + c does not work.

Possibly related to https://stackoverflow.com/questions/31350335/docker-not-responding-to-ctrlc-in-terminal and we just need to add --init to https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/fd8b9e630e1ea0d34349bc2b27da7ba7da0bb964/scripts/dev#L43