### PR TITLE
Remove gcp auth provider overrides 

### DIFF
--- a/marketplace/dev/bin/setup_config.sh
+++ b/marketplace/dev/bin/setup_config.sh
@@ -20,7 +20,7 @@ set -eo pipefail
 # default $KUBECONFIG location.
 if [[ -e "/mount/config/.kube/config" ]]; then
   mkdir -p "$HOME/.kube"
-  cp /mount/config/.kube/config > "$HOME/.kube/config"
+  cp /mount/config/.kube/config "$HOME/.kube/config"
 fi
 
 # If host gcloud configuration is mounted, replace container gcloud

--- a/marketplace/dev/bin/setup_config.sh
+++ b/marketplace/dev/bin/setup_config.sh
@@ -17,23 +17,10 @@
 set -eo pipefail
 
 # If host kubernetes configuration is mounted, copy it to the container's
-# default $KUBECONFIG location after adjusting system-specific fields.
+# default $KUBECONFIG location.
 if [[ -e "/mount/config/.kube/config" ]]; then
   mkdir -p "$HOME/.kube"
-
-  # Adjusting cmd-path for gcp auth-providers to this container's gcloud
-  # installation location.
-  cat /mount/config/.kube/config \
-    | yaml2json \
-    | jq \
-          --arg gcloud "$(readlink -f "$(which gcloud)")" \
-          '.users = [ .users[] |
-                      if .user["auth-provider"]["name"] == "gcp" and .user["auth-provider"]["config"]["cmd-path"]
-                        then .user["auth-provider"]["config"]["cmd-path"] = $gcloud
-                        else .
-                      end
-                    ]' \
-  > "$HOME/.kube/config"
+  cp /mount/config/.kube/config > "$HOME/.kube/config"
 fi
 
 # If host gcloud configuration is mounted, replace container gcloud


### PR DESCRIPTION
This is obsolete after moving to gke-gcloud-auth-plugin

See: https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke