### PR TITLE
Update helm and kubectl to latest versions

### DIFF
--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -25,7 +25,7 @@ RUN for full_version in 1.23.13 1.24.7 1.25.4;  \
             https://storage.googleapis.com/kubernetes-release/release/v$full_version/bin/linux/amd64/kubectl \
         && chmod 755 /opt/kubectl/$version/kubectl; \
      done;
-RUN ln -s /opt/kubectl/1.22 /opt/kubectl/default
+RUN ln -s /opt/kubectl/1.24 /opt/kubectl/default
 
 COPY marketplace/deployer_envsubst_base/* /bin/
 COPY marketplace/deployer_util/* /bin/

--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -17,7 +17,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.22.12 1.24.3;  \
+RUN for full_version in 1.23.13 1.24.7 1.25.4;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -25,7 +25,7 @@ RUN for full_version in 1.23.13 1.24.7 1.25.4;  \
             https://storage.googleapis.com/kubernetes-release/release/v$full_version/bin/linux/amd64/kubectl \
         && chmod 755 /opt/kubectl/$version/kubectl; \
      done;
-RUN ln -s /opt/kubectl/1.22 /opt/kubectl/default
+RUN ln -s /opt/kubectl/1.24 /opt/kubectl/default
 
 RUN mkdir -p /bin/helm-downloaded \
     && wget -q -O /bin/helm-downloaded/helm.tar.gz \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -17,7 +17,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.22.12 1.24.3;  \
+RUN for full_version in 1.23.13 1.24.7 1.25.4;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \
@@ -29,7 +29,7 @@ RUN ln -s /opt/kubectl/1.22 /opt/kubectl/default
 
 RUN mkdir -p /bin/helm-downloaded \
     && wget -q -O /bin/helm-downloaded/helm.tar.gz \
-        https://get.helm.sh/helm-v3.10.0-linux-amd64.tar.gz \
+        https://get.helm.sh/helm-v3.10.3-linux-amd64.tar.gz \
     && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
     && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
     && rm -rf /bin/helm-downloaded

--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -35,7 +35,7 @@ RUN for full_version in 1.23.13 1.24.7 1.25.4;  \
             https://storage.googleapis.com/kubernetes-release/release/v$full_version/bin/linux/amd64/kubectl \
         && chmod 755 /opt/kubectl/$version/kubectl; \
      done;
-RUN ln -s /opt/kubectl/1.22 /opt/kubectl/default
+RUN ln -s /opt/kubectl/1.24 /opt/kubectl/default
 
 RUN echo "deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu focal edge" | tee /etc/apt/sources.list.d/docker.list \
      && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key --keyring /usr/share/keyrings/docker.gpg add - \

--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -27,7 +27,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.22.12 1.24.3;  \
+RUN for full_version in 1.23.13 1.24.7 1.25.4;  \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \
@@ -44,7 +44,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker
 
 RUN mkdir -p /bin/helm-downloaded \
      && wget -q -O /bin/helm-downloaded/helm.tar.gz \
-        https://get.helm.sh/helm-v3.10.0-linux-amd64.tar.gz \
+        https://get.helm.sh/helm-v3.10.3-linux-amd64.tar.gz \
      && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
      && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
      && rm -rf /bin/helm-downloaded


### PR DESCRIPTION
* kubectl versions updated to 1.23.13 1.24.7 1.25.4 following https://cloud.google.com/kubernetes-engine/docs/release-notes
* helm updated to 3.10.3 from https://github.com/helm/helm/releases