### PR TITLE
Update helm and kubectl versions

### DIFF
--- a/marketplace/deployer_envsubst_base/Dockerfile
+++ b/marketplace/deployer_envsubst_base/Dockerfile
@@ -17,7 +17,7 @@ RUN pip3 install \
       pyyaml \
       six
 
-RUN for full_version in 1.27.8 1.29.1;  \
+RUN for full_version in 1.27.15 1.29.6; \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \

--- a/marketplace/deployer_helm_base/Dockerfile
+++ b/marketplace/deployer_helm_base/Dockerfile
@@ -16,7 +16,7 @@ RUN pip3 install \
       pyOpenSSL \
       pyyaml
 
-RUN for full_version in 1.27.8 1.29.1;  \
+RUN for full_version in 1.27.15 1.29.6; \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \
@@ -28,7 +28,7 @@ RUN ln -s /opt/kubectl/1.27 /opt/kubectl/default
 
 RUN mkdir -p /bin/helm-downloaded \
     && wget -q -O /bin/helm-downloaded/helm.tar.gz \
-        https://get.helm.sh/helm-v3.14.3-linux-amd64.tar.gz \
+        https://get.helm.sh/helm-v3.15.2-linux-amd64.tar.gz \
     && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
     && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
     && rm -rf /bin/helm-downloaded

--- a/marketplace/dev/Dockerfile
+++ b/marketplace/dev/Dockerfile
@@ -25,7 +25,7 @@ RUN pip3 install \
       pyOpenSSL \
       pyyaml
 
-RUN for full_version in 1.27.8 1.29.1;  \
+RUN for full_version in 1.27.15 1.29.6; \
      do \
         version=${full_version%.*} \
         && mkdir -p /opt/kubectl/$version \
@@ -41,7 +41,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker
      && apt-get -y install docker-ce
 RUN mkdir -p /bin/helm-downloaded \
      && wget -q -O /bin/helm-downloaded/helm.tar.gz \
-        https://get.helm.sh/helm-v3.14.3-linux-amd64.tar.gz \
+        https://get.helm.sh/helm-v3.15.2-linux-amd64.tar.gz \
      && tar -zxvf /bin/helm-downloaded/helm.tar.gz -C /bin/helm-downloaded \
      && mv /bin/helm-downloaded/linux-amd64/helm /bin/ \
      && rm -rf /bin/helm-downloaded


### PR DESCRIPTION
The versions of helm and kubectl currently being installed are affected by [CVE-2024-24790](https://nvd.nist.gov/vuln/detail/CVE-2024-24790), which makes the marketplace's validation process fail with the following error:

```
  "taskReports": [
    {
      "taskType": "CHECK_PACKAGE_VULNERABILITIES",
      "createTime": "2024-06-25T11:07:08.452Z",
      "taskExecutionStatus": "ISSUES_FOUND",
      "digest": "Entity has one or more images with vulnerabilities.",
      "errorMessage": "Packages below are known to contain vulnerabilities. Please update the affected packages and resubmit the solution\n\nImage: https://gcr.io/cloud-launcher-images-prd/<redacted>\n  Note: CVE-2024-24790\n  Package: go\n  Package Type: GO_STDLIB\n  Affected Version: 1.20.11\n  Fixed Version: 1.21.11\n  Package: go\n  Package Type: GO_STDLIB\n  Affected Version: 1.21.6\n  Fixed Version: 1.21.11\n  Package: go\n  Package Type: GO_STDLIB\n  Affected Version: 1.21.7\n  Fixed Version: 1.21.11"
    },
```