### PR TITLE
Use "docker cp" to copy schema in install and verify script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -72,12 +72,9 @@ else
 fi
 
 # Extract schema and values files.
-docker run \
-    -i \
-    --entrypoint=/bin/bash \
-    --rm "${deployer}" \
-    -c 'cat /data/schema.yaml' \
-> /data/schema.yaml
+container_id=$(docker create "${deployer}")
+docker cp "$container_id:/data/schema.yaml" /data/schema.yaml
+docker rm "$container_id"
 echo "INFO: /data/schema.yaml:"
 cat /data/schema.yaml
 echo "$parameters" \

--- a/scripts/verify
+++ b/scripts/verify
@@ -168,11 +168,9 @@ handle_failure() {
 trap "handle_failure" EXIT
 
 # Extract schema and values files.
-docker run \
-    --entrypoint=/bin/bash \
-    --rm "${deployer}" \
-    -c 'cat /data/schema.yaml' \
-> /data/schema.yaml
+container_id=$(docker create "${deployer}")
+docker cp "$container_id:/data/schema.yaml" /data/schema.yaml
+docker rm "$container_id"
 
 # If parameters is a gcs file, use the content of the file instead
 if [[ "$parameters" = "gs://"* ]]; then


### PR DESCRIPTION
Using docker cp without relying on the shell redirection to the local filesystem.