### PR TITLE
Update location of helm charts

### DIFF
--- a/docs/building-deployer-helm.md
+++ b/docs/building-deployer-helm.md
@@ -267,7 +267,7 @@ Use the following content for `requirements.yaml`.
 dependencies:
 - name: wordpress
   version: 9.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
 ```
 
 For starters, use an empty `values.yaml`. The nice thing about this


### PR DESCRIPTION
The helm chart location has moved, this updates that link.

Ref: https://helm.sh/blog/new-location-stable-incubator-charts/