### PR TITLE
docs: note current kubectl version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ Build container images:
 ```shell
 make marketplace/build
 ```
+
+## Kubectl versions
+
+Using latest stable kubectl, as of 6/30, it's 1.36.2


### PR DESCRIPTION
Update README.md to document that we are using the latest stable kubectl version, which is 1.36.2 as of June 30, 2026.