### PR TITLE
Fix race condition in weekly release

### DIFF
--- a/.github/workflows/create-weekly-image-update-release.yml
+++ b/.github/workflows/create-weekly-image-update-release.yml
@@ -19,6 +19,43 @@ jobs:
           fetch-depth: 0 # Fetch all history and tags
           token: ${{ secrets.PRODUCER_SAAP_BOT_PAT }}
 
+      - name: Wait for Staging Images Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRODUCER_SAAP_BOT_PAT }}
+        run: |
+          SHA="${{ github.sha }}"
+          CHECK_NAME="Push-marketplace-k8s-app-tools (marketplace-k8s-app-tools)"
+          echo "Waiting for check '$CHECK_NAME' on commit $SHA to succeed..."
+          
+          max_attempts=30 # 30 minutes timeout
+          attempt=0
+          while [ $attempt -lt $max_attempts ]; do
+            # Query the check runs for the current commit
+            RESULT=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
+              --jq ".check_runs[] | select(.name == \"$CHECK_NAME\") | {status, conclusion}")
+            
+            STATUS=$(echo "$RESULT" | jq -r '.status // empty')
+            CONCLUSION=$(echo "$RESULT" | jq -r '.conclusion // empty')
+            
+            echo "Attempt $((attempt+1))/$max_attempts: Status=$STATUS, Conclusion=$CONCLUSION"
+            
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "Staging build succeeded. Proceeding with release."
+                exit 0
+              else
+                echo "Staging build failed with conclusion: $CONCLUSION"
+                exit 1
+              fi
+            fi
+            
+            attempt=$((attempt+1))
+            sleep 60
+          done
+          
+          echo "Timeout waiting for staging build to complete."
+          exit 1
+
       - name: Calculate Next Tag
         id: calculate_tag
         run: |

--- a/.github/workflows/create-weekly-image-update-release.yml
+++ b/.github/workflows/create-weekly-image-update-release.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write # Required to create tags and releases
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0 # Fetch all history and tags
           token: ${{ secrets.PRODUCER_SAAP_BOT_PAT }}
@@ -22,8 +22,9 @@ jobs:
       - name: Wait for Staging Images Build
         env:
           GITHUB_TOKEN: ${{ secrets.PRODUCER_SAAP_BOT_PAT }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
         run: |
-          SHA="${{ github.sha }}"
           CHECK_NAME="Push-marketplace-k8s-app-tools (marketplace-k8s-app-tools)"
           echo "Waiting for check '$CHECK_NAME' on commit $SHA to succeed..."
           
@@ -31,7 +32,7 @@ jobs:
           attempt=0
           while [ $attempt -lt $max_attempts ]; do
             # Query the check runs for the current commit
-            RESULT=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
+            RESULT=$(gh api repos/$REPO/commits/$SHA/check-runs \
               --jq ".check_runs[] | select(.name == \"$CHECK_NAME\") | {status, conclusion}")
             
             STATUS=$(echo "$RESULT" | jq -r '.status // empty')
@@ -79,14 +80,17 @@ jobs:
           echo "NEW_TAG=$NEW_TAG" >> $GITHUB_OUTPUT
 
       - name: Create and Push Tag
+        env:
+          NEW_TAG: ${{ steps.calculate_tag.outputs.NEW_TAG }}
         run: |
-          git tag "${{ steps.calculate_tag.outputs.NEW_TAG }}"
-          git push origin "${{ steps.calculate_tag.outputs.NEW_TAG }}"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
 
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.PRODUCER_SAAP_BOT_PAT }}
+          NEW_TAG: ${{ steps.calculate_tag.outputs.NEW_TAG }}
         run: |
-          gh release create "${{ steps.calculate_tag.outputs.NEW_TAG }}" \
-            --title "${{ steps.calculate_tag.outputs.NEW_TAG }}" \
+          gh release create "$NEW_TAG" \
+            --title "$NEW_TAG" \
             --generate-notes


### PR DESCRIPTION
This PR adds a step to wait for the staging build to complete successfully before creating the tag and release, resolving a race condition where the prod build would try to pull non-existent staging images.