### PR TITLE
Set ccm-saap-team as reviewer for weekly image update PR

### DIFF
--- a/.github/workflows/weekly-image-update.yml
+++ b/.github/workflows/weekly-image-update.yml
@@ -69,13 +69,12 @@ jobs:
           PR_URL=$(gh pr list --head "$BRANCH_NAME" --state open --json url --jq '.[0].url')
           if [ -z "$PR_URL" ]; then
             PR_TITLE="Weekly Kubectl Image Rebuild"
-            # TODO: Once verified, consider replacing --assignee with --reviewer to target the whole team
             PR_URL=$(gh pr create \
               --title "$PR_TITLE" \
               --body "Automated PR to trigger weekly kubectl image rebuild. Merging this PR will release updated images." \
               --head "$BRANCH_NAME" \
               --repo "$GITHUB_REPOSITORY" \
-              --reviewer "erikcandeia,lamjonathan")
+              --reviewer "GoogleCloudPlatform/ccm-saap-team")
             echo "Created PR: $PR_URL"
           else
             echo "PR already exists: $PR_URL. Updated branch will trigger new builds."

--- a/.github/workflows/weekly-image-update.yml
+++ b/.github/workflows/weekly-image-update.yml
@@ -75,7 +75,7 @@ jobs:
               --body "Automated PR to trigger weekly kubectl image rebuild. Merging this PR will release updated images." \
               --head "$BRANCH_NAME" \
               --repo "$GITHUB_REPOSITORY" \
-              --assignee "erikcandeia,lamjonathan")
+              --reviewer "erikcandeia,lamjonathan")
             echo "Created PR: $PR_URL"
           else
             echo "PR already exists: $PR_URL. Updated branch will trigger new builds."

--- a/.github/workflows/weekly-image-update.yml
+++ b/.github/workflows/weekly-image-update.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write # To create PRs, assign reviewers, comment on PRs
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           token: ${{ secrets.PRODUCER_SAAP_BOT_PAT }}
 
@@ -44,20 +44,26 @@ jobs:
           git reset --hard origin/master
 
       - name: Update Changelog File
+        env:
+          LOG_ENTRY: ${{ steps.dates.outputs.LOG_ENTRY }}
         run: |
           # Append to AUTOBUILD_CHANGELOG.md (creates it if it does not exist)
-          echo "${{ steps.dates.outputs.LOG_ENTRY }}" >> AUTOBUILD_CHANGELOG.md
+          echo "$LOG_ENTRY" >> AUTOBUILD_CHANGELOG.md
           echo "AUTOBUILD_CHANGELOG.md updated."
 
       - name: Commit changes
+        env:
+          LOG_ENTRY: ${{ steps.dates.outputs.LOG_ENTRY }}
         run: |
           git add AUTOBUILD_CHANGELOG.md
-          git commit -m "Automated weekly image rebuild trigger: ${{ steps.dates.outputs.LOG_ENTRY }}"
+          git commit -m "Automated weekly image rebuild trigger: $LOG_ENTRY"
 
       - name: Push Branch
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}
         run: |
           # Force push is required since we reset the branch to origin/master
-          git push -f origin ${{ steps.branch.outputs.BRANCH_NAME }}
+          git push -f origin "$BRANCH_NAME"
 
       - name: Create or Locate Pull Request
         id: create_pr
@@ -85,5 +91,6 @@ jobs:
         if: steps.create_pr.outputs.PR_URL != ''
         env:
           GITHUB_TOKEN: ${{ secrets.PRODUCER_SAAP_BOT_PAT }}
+          PR_URL: ${{ steps.create_pr.outputs.PR_URL }}
         run: |
-          gh pr comment ${{ steps.create_pr.outputs.PR_URL }} --body "/gcbrun"
+          gh pr comment "$PR_URL" --body "/gcbrun"


### PR DESCRIPTION
Update `weekly-image-update.yml` to set the reviewer for the automated weekly PRs to the team `GoogleCloudPlatform/ccm-saap-team` instead of individual reviewers.

Also removed the obsolete TODO comment.