### PR TITLE
Fix public image tag rotation digest error

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -62,8 +62,8 @@ steps:
       if [[ -n "$old_public_tag" ]]; then
         local old_version="${old_public_tag#public-image-}"
         local old_digest
-        old_digest=$(gcloud container images list-tags "$image_name" \
-          --filter="tags:$old_public_tag" --format="value(digest)")
+        old_digest=$(gcloud container images describe "$image_name:$old_public_tag" \
+          --format="value(image_summary.digest)")
         
         echo "[$image_name] Found old public image version: $old_version (digest: $old_digest)"
         


### PR DESCRIPTION
### Issue
The GCB tag rotation step "Manage Public Image Tags" failed with the following error:
`ERROR: (gcloud.container.images.add-tag) [gcr.io/...@ad02c056f254] digest must be of the form "sha256:<digest>".`

### Root Cause
The script was using `gcloud container images list-tags` to retrieve the digest of the old public image tag. However, `list-tags` truncates the digest to a 12-character short SHA by default. Even when using `--format="value(digest)"`, it returned the truncated value (e.g., `ad02c056f254`) without the required `sha256:` prefix. This truncated digest is invalid for the subsequent `add-tag` command.

### Proposed Fix & Justification
Replaced `gcloud container images list-tags` with `gcloud container images describe` to retrieve the digest of the specific old tag. 
Using `describe` with `--format="value(image_summary.digest)"` retrieves the full, untruncated 64-character SHA256 digest with the `sha256:` prefix, which is the correct format required by the `add-tag` command.
