### PR TITLE
Fix docker command not found in GCB tag rotation

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -74,9 +74,8 @@ steps:
         gcloud container images add-tag "$image_name@$old_digest" "$image_name:deprecated-public-image-$old_version" --quiet
       fi
 
-      # Tag the new image ($TAG_NAME) locally and push it
-      docker tag "$image_name:$TAG_NAME" "$image_name:public-image-$TAG_NAME"
-      docker push "$image_name:public-image-$TAG_NAME"
+      # Tag the new image ($TAG_NAME) as public-image-$TAG_NAME registry-side
+      gcloud container images add-tag "$image_name:$TAG_NAME" "$image_name:public-image-$TAG_NAME" --quiet
     }
 
     # Run for all 5 images


### PR DESCRIPTION
### Issue
The GCB tag rotation step "Manage Public Image Tags" failed with the following error:
`environment: line 33: docker: command not found`

### Root Cause
The step uses the `gcr.io/cloud-builders/gcloud` builder image, which contains `gcloud` but does not have the `docker` CLI installed. The script attempted to use `docker tag` and `docker push` to tag the new image.

### Proposed Fix & Justification
Replaced the `docker tag` and `docker push` commands with `gcloud container images add-tag`. This allows tagging the image directly in the registry (GCR) without requiring a local Docker daemon or CLI.
