### PR TITLE
Fix GCB 404 Not Found by refactoring to registry-side gcloud tagging

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -13,27 +13,18 @@ substitutions:
 steps:
 
 - id: &PublishImages Publish Images
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/cloud-builders/gcloud
   waitFor:
   - '-'
   entrypoint: bash
   args:
   - -ceux
   - |
-    docker pull gcr.io/$_STAGING_PROJECT_ID/k8s/dev:sha_$COMMIT_SHA
-    docker tag gcr.io/$_STAGING_PROJECT_ID/k8s/dev:sha_$COMMIT_SHA gcr.io/$PROJECT_ID/k8s/dev:$TAG_NAME
-
-    docker pull gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_helm:sha_$COMMIT_SHA
-    docker tag gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_helm:sha_$COMMIT_SHA gcr.io/$PROJECT_ID/k8s/deployer_helm:$TAG_NAME
-
-    docker pull gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_helm/onbuild:sha_$COMMIT_SHA
-    docker tag gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_helm/onbuild:sha_$COMMIT_SHA gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:$TAG_NAME
-
-    docker pull gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_envsubst:sha_$COMMIT_SHA
-    docker tag gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_envsubst:sha_$COMMIT_SHA gcr.io/$PROJECT_ID/k8s/deployer_envsubst:$TAG_NAME
-
-    docker pull gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_envsubst/onbuild:sha_$COMMIT_SHA
-    docker tag gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_envsubst/onbuild:sha_$COMMIT_SHA gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:$TAG_NAME
+    gcloud container images add-tag "gcr.io/$_STAGING_PROJECT_ID/k8s/dev:sha_$COMMIT_SHA" "gcr.io/$PROJECT_ID/k8s/dev:$TAG_NAME" --quiet
+    gcloud container images add-tag "gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_helm:sha_$COMMIT_SHA" "gcr.io/$PROJECT_ID/k8s/deployer_helm:$TAG_NAME" --quiet
+    gcloud container images add-tag "gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_helm/onbuild:sha_$COMMIT_SHA" "gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:$TAG_NAME" --quiet
+    gcloud container images add-tag "gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_envsubst:sha_$COMMIT_SHA" "gcr.io/$PROJECT_ID/k8s/deployer_envsubst:$TAG_NAME" --quiet
+    gcloud container images add-tag "gcr.io/$_STAGING_PROJECT_ID/k8s/deployer_envsubst/onbuild:sha_$COMMIT_SHA" "gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:$TAG_NAME" --quiet
 
 - id: Manage Public Image Tags
   name: gcr.io/cloud-builders/gcloud
@@ -95,7 +86,7 @@ steps:
   - echo "$(.cloudbuild/should_tag_latest.sh gcr.io/$PROJECT_ID/k8s/dev $TAG_NAME)" > should_tag_latest
 
 - id: &MaybeTagImagesLatest Maybe tag images latest
-  name: gcr.io/cloud-builders/docker
+  name: gcr.io/cloud-builders/gcloud
   waitFor:
   - *DetermineShouldTagLatest
   entrypoint: /bin/bash
@@ -103,16 +94,11 @@ steps:
   - -ceux
   - |
     if [[ "$(cat should_tag_latest)" == "true" ]]; then
-      docker tag gcr.io/$PROJECT_ID/k8s/dev:$TAG_NAME gcr.io/$PROJECT_ID/k8s/dev:latest
-      docker push gcr.io/$PROJECT_ID/k8s/dev:latest
-      docker tag gcr.io/$PROJECT_ID/k8s/deployer_helm:$TAG_NAME gcr.io/$PROJECT_ID/k8s/deployer_helm:latest
-      docker push gcr.io/$PROJECT_ID/k8s/deployer_helm:latest
-      docker tag gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:$TAG_NAME gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:latest
-      docker push gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:latest
-      docker tag gcr.io/$PROJECT_ID/k8s/deployer_envsubst:$TAG_NAME gcr.io/$PROJECT_ID/k8s/deployer_envsubst:latest
-      docker push gcr.io/$PROJECT_ID/k8s/deployer_envsubst:latest
-      docker tag gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:$TAG_NAME gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:latest
-      docker push gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:latest
+      gcloud container images add-tag "gcr.io/$PROJECT_ID/k8s/dev:$TAG_NAME" "gcr.io/$PROJECT_ID/k8s/dev:latest" --quiet
+      gcloud container images add-tag "gcr.io/$PROJECT_ID/k8s/deployer_helm:$TAG_NAME" "gcr.io/$PROJECT_ID/k8s/deployer_helm:latest" --quiet
+      gcloud container images add-tag "gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:$TAG_NAME" "gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:latest" --quiet
+      gcloud container images add-tag "gcr.io/$PROJECT_ID/k8s/deployer_envsubst:$TAG_NAME" "gcr.io/$PROJECT_ID/k8s/deployer_envsubst:latest" --quiet
+      gcloud container images add-tag "gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:$TAG_NAME" "gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:latest" --quiet
     else
       echo "Not tagging latest"
     fi


### PR DESCRIPTION
### Issue
During the tag release GCB build, the "Manage Public Image Tags" step failed with a 404 "Not Found" error when attempting to add tags to the new image version (e.g. `13.0.7`).

### Root Cause
1. In Step 1 ("Publish Images"), we only tagged the images locally using `docker tag`. The images were not pushed to GCR at this stage (GCB normally pushes them at the end of the build).
2. In Step 2 ("Manage Public Image Tags"), we used `gcloud container images add-tag` to assign public tags to the new release.
3. Because `gcloud` operates registry-side and the new release image had not yet been pushed to the GCR registry, GCR returned a 404 error.

### Suggested Fix
Refactor the GCB configuration to use registry-side `gcloud` commands instead of local `docker` commands for all publishing and tagging steps:
1. In Step 1, replace `docker pull/tag` with `gcloud container images add-tag` to copy/publish the images from the staging registry to the production registry immediately.
2. In Step 4 ("Maybe tag images latest"), replace `docker tag/push` with `gcloud container images add-tag` for registry-side tagging.

### Why the Fix Works
* Publishing the images in Step 1 ensures they exist in the production GCR registry before Step 2 runs.
* Step 2's `gcloud add-tag` command will succeed because the source image is now present in the registry.
* Eliminating local Docker operations makes the build faster and avoids pulling large images to the runner.

