### PR TITLE
Fix GCB build failure by removing images section after gcloud refactor

### DIFF
--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -119,13 +119,6 @@ steps:
     gcloud storage cp gs://$PROJECT_ID/charts/index.yaml index.yaml
     helm repo index --merge index.yaml charts-tgz/
 
-images:
-- gcr.io/$PROJECT_ID/k8s/dev:$TAG_NAME
-- gcr.io/$PROJECT_ID/k8s/deployer_helm:$TAG_NAME
-- gcr.io/$PROJECT_ID/k8s/deployer_helm/onbuild:$TAG_NAME
-- gcr.io/$PROJECT_ID/k8s/deployer_envsubst:$TAG_NAME
-- gcr.io/$PROJECT_ID/k8s/deployer_envsubst/onbuild:$TAG_NAME
-
 artifacts:
   objects:
     location: gs://$PROJECT_ID/charts/


### PR DESCRIPTION
### Issue
After refactoring the GCB tag release configuration to use registry-side `gcloud` tagging (to fix the 404 Not Found error), the build failed at the very end with the following error:
`ERROR: failed to find one or more images after execution of build steps`

### Root Cause
* The GCB configuration had an `images:` section listing the release images (e.g. `gcr.io/$PROJECT_ID/k8s/dev:$TAG_NAME`).
* GCB's native `images:` handler attempts to push these images from the runner's local Docker daemon at the end of the build.
* Because we switched to registry-side tagging using `gcloud` in Step 1, these images were never pulled locally (except for `k8s/dev` which was pulled as a builder for the charts step).
* Since the other images did not exist locally on the runner, GCB failed to find them for the automatic push step.

### Suggested Fix & Justification
Remove the `images:` section from `cloudbuild-tag.yaml`.
* **Justification:** Since the images are already copied and tagged directly in the production registry during Step 1 (`Publish Images`) using `gcloud`, GCB does not need to push them again. Removing this section prevents GCB from looking for local copies and allows the build to complete successfully. The only trade-off is that these images won't be listed in the GCB console's "Build Artifacts" metadata, but they are fully published and available in GCR.
